### PR TITLE
Export the VrDeviceInfo fields

### DIFF
--- a/raylib/raylib.go
+++ b/raylib/raylib.go
@@ -841,25 +841,25 @@ const (
 // VrDeviceInfo - Head-Mounted-Display device parameters
 type VrDeviceInfo struct {
 	// HMD horizontal resolution in pixels
-	hResolution int
+	HResolution int
 	// HMD vertical resolution in pixels
-	vResolution int
+	VResolution int
 	// HMD horizontal size in meters
-	hScreenSize float32
+	HScreenSize float32
 	// HMD vertical size in meters
-	vScreenSize float32
+	VScreenSize float32
 	// HMD screen center in meters
-	vScreenCenter float32
+	VScreenCenter float32
 	// HMD distance between eye and display in meters
-	eyeToScreenDistance float32
+	EyeToScreenDistance float32
 	// HMD lens separation distance in meters
-	lensSeparationDistance float32
+	LensSeparationDistance float32
 	// HMD IPD (distance between pupils) in meters
-	interpupillaryDistance float32
+	InterpupillaryDistance float32
 	// HMD lens distortion constant parameters
-	lensDistortionValues [4]float32
+	LensDistortionValues [4]float32
 	// HMD chromatic aberration correction parameters
-	chromaAbCorrection [4]float32
+	ChromaAbCorrection [4]float32
 }
 
 // NewVrDeviceInfo - Returns new VrDeviceInfo


### PR DESCRIPTION
Started trying out raylib-go today, and noticed the fields in `VrDeviceInfo` aren't exported, which makes some things a bit weird to try and use.

For example, with the VR Simulator er... [example](https://github.com/gen2brain/raylib-go/blob/9b24dc61cfef0edecabcd62e45f1c28bb184e341/examples/core/vr_simulator/main.go#L8-L16), it's currently using hard coded values because it can't read them out of the structure.  If the fields are exported, then the VR example could be simplified ([something like this](https://github.com/justinclift/raylib-go/commit/83fae0be2e6a563eb4dbf028eb5ac1bd6c1ab501)) to just read the needed data directly.

Workable? :smile: