### PR TITLE
Adjust drop_files example to cope with multiple dropped files

### DIFF
--- a/examples/core/drop_files/main.go
+++ b/examples/core/drop_files/main.go
@@ -35,10 +35,10 @@ func main() {
 					raylib.DrawRectangle(0, int32(85+40*i), screenWidth, 40, raylib.Fade(raylib.LightGray, 0.3))
 				}
 
-				raylib.DrawText(droppedFiles[i], 120, int32(100), 10, raylib.Gray)
+				raylib.DrawText(droppedFiles[i], 120, int32(100+i*40), 10, raylib.Gray)
 			}
 
-			raylib.DrawText("Drop new files...", 100, int32(150), 20, raylib.DarkGray)
+			raylib.DrawText("Drop new files...", 100, int32(150+count*40), 20, raylib.DarkGray)
 		}
 
 		raylib.EndDrawing()


### PR DESCRIPTION
There's a small bug in the drop_files example, whereby it does fine with single files being dropped but doesn't correctly calculate text position when multiple files are.  This PR addresses that.

### Before

#### Single file
![drop_files_bug1](https://user-images.githubusercontent.com/406299/44346596-408b9180-a48e-11e8-82e3-3c8629c75656.png)
#### Multiple files
![drop_files_bug2](https://user-images.githubusercontent.com/406299/44346599-408b9180-a48e-11e8-8969-77c2a3e2d7d9.png)

It turns out this isn't a great example screenshot, as all of the file names are short so it's hard to see them writing over the top of each other. :roll_eyes: 

### After

#### Single file
![drop_files_bug3](https://user-images.githubusercontent.com/406299/44346748-a1b36500-a48e-11e8-895a-91345c80bfbd.png)
#### Multiple files
![drop_files_bug4](https://user-images.githubusercontent.com/406299/44346756-a7a94600-a48e-11e8-8ebe-54fc6fcd9733.png)