### PR TITLE
Give exact size values to make() to prevent panic-ing

### DIFF
--- a/raylib/core.go
+++ b/raylib/core.go
@@ -275,7 +275,7 @@ func ColorNormalize(color Color) Vector4 {
 
 // Vector3ToFloat - Converts Vector3 to float32 slice
 func Vector3ToFloat(vec Vector3) []float32 {
-	data := make([]float32, 0)
+	data := make([]float32, 3)
 	data[0] = vec.X
 	data[1] = vec.Y
 	data[2] = vec.Z
@@ -285,7 +285,7 @@ func Vector3ToFloat(vec Vector3) []float32 {
 
 // MatrixToFloat - Converts Matrix to float32 slice
 func MatrixToFloat(mat Matrix) []float32 {
-	data := make([]float32, 0)
+	data := make([]float32, 16)
 
 	data[0] = mat.M0
 	data[1] = mat.M4


### PR DESCRIPTION
Discovered these while eyeballing some of the code.  Without a large enough allocation in the up front `make()` these two functions will crash.

An alternative fix would be to use `append()` for each of the elements instead, to expand out the slice one by one.  That's probably far less efficient than just allocating sufficient space from the start. :smile: