### PR TITLE
Fix: NewImageFromImage() height incorrect.

### DIFF
--- a/raylib/raylib.go
+++ b/raylib/raylib.go
@@ -1113,7 +1113,7 @@ func NewImageFromImage(img image.Image) *Image {
 		for x := 0; x < size.X; x++ {
 			color := img.At(x, y)
 			r, g, b, a := color.RGBA()
-			pixels[x+y*size.Y] = NewColor(uint8(r), uint8(g), uint8(b), uint8(a))
+			pixels[x+y*size.X] = NewColor(uint8(r), uint8(g), uint8(b), uint8(a))
 		}
 	}
 


### PR DESCRIPTION
Previously, the function broke on non-rectangular images.
Y needs to be multiplied by the horizontal width, not the image's reported height.