### PR TITLE
Fedora 31 out-of-box README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Golang bindings for [raylib](http://www.raylib.com/), a simple and easy-to-use l
 
 ##### Fedora
 
+As of a fresh install of Fedora 31, you may need to do the installs for _both Wayland and X11_ to complete installation. 
+If you get `missing wayland-xdg-shell-client-protocol.h include` or any other missing includes specific to X11/Wayland
+during the install process and you have only completed one of the installs here consider also installing the other set.
+
 ###### X11
 
     dnf install mesa-libGL-devel libXi-devel libXcursor-devel libXrandr-devel libXinerama-devel


### PR DESCRIPTION
I'm sorry if there are contribution guidelines. If there are, I'm happy to withdraw the PR and redo under contributions.

On Fedora 31, I had to install _both_ the X11 and Wayland packages listed in the 'requirements' section before I could successfully run the installation. To be clear, that was true regardless of whether I installed with or without the wayland tag. Updates the README to include this (admittedly rudimentary) suggestion.

I don't mind at all if this isn't merged, I just wanted to try to share the 'button presses that worked for me' update.