### PR TITLE
adding SetTraceLogCallback

### DIFF
--- a/examples/utils/utils.go
+++ b/examples/utils/utils.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"github.com/gen2brain/raylib-go/raylib"
+	"log"
+)
+
+func main() {
+	rl.SetTraceLogCallback(func(logType int, str string) {
+		level := ""
+		switch logType {
+		case rl.LogDebug:
+			level = "Debug"
+		case rl.LogError:
+			level = "Error"
+		case rl.LogInfo:
+			level = "Info"
+		case rl.LogTrace:
+			level = "Trace"
+		case rl.LogWarning:
+			level = "Warning"
+		case rl.LogFatal:
+			level = "Fatal"
+		}
+		if logType != rl.LogFatal {
+			log.Printf("%s - %s", level, str)
+		} else {
+			log.Fatalf("%s - %s", level, str)
+		}
+	})
+
+	rl.SetConfigFlags(rl.FlagVsyncHint)
+	rl.InitWindow(800, 450, "raylib [utils] example - SetTraceLogCallback")
+
+	for !rl.WindowShouldClose() {
+		rl.BeginDrawing()
+
+		rl.ClearBackground(rl.RayWhite)
+
+		rl.DrawText("The raylib trace log is controlled in GO!", 190, 200, 20, rl.LightGray)
+
+		rl.EndDrawing()
+	}
+
+	rl.CloseWindow()
+}

--- a/raylib/utils_log.c
+++ b/raylib/utils_log.c
@@ -1,0 +1,18 @@
+#include "raylib.h"
+#include "utils_log.h"
+#include <stdio.h>                      // Required for: vprintf()
+#include <string.h>                     // Required for: strcpy(), strcat()
+
+#define MAX_TRACELOG_BUFFER_SIZE   128  // As defined in utils.c from raylib
+
+void rayLogWrapperCallback(int logType, const char *text, va_list args) {
+	char buffer[MAX_TRACELOG_BUFFER_SIZE] = { 0 };
+
+	vsprintf(buffer, text, args);
+
+	internalTraceLogCallbackGo(logType, buffer, strlen(buffer));
+}
+
+void setLogCallbackWrapper(void) {
+	SetTraceLogCallback(rayLogWrapperCallback);
+}

--- a/raylib/utils_log.go
+++ b/raylib/utils_log.go
@@ -1,0 +1,26 @@
+package rl
+
+/*
+#include "utils_log.h"
+*/
+import "C"
+
+import "unsafe"
+
+// TraceLogCallbackFun - function that will recive the trace log messages
+type TraceLogCallbackFun func(int, string)
+
+var internalTraceLogCallbackFun TraceLogCallbackFun = func(int, string) {}
+
+// SetTraceLogCallback - set a call-back function for trace log
+func SetTraceLogCallback(fn TraceLogCallbackFun) {
+	internalTraceLogCallbackFun = fn
+	C.setLogCallbackWrapper()
+}
+
+//export internalTraceLogCallbackGo
+func internalTraceLogCallbackGo(logType C.int, cstr unsafe.Pointer, len C.int) {
+	str := string(C.GoBytes(cstr, len))
+	lt := int(logType)
+	internalTraceLogCallbackFun(lt, str)
+}

--- a/raylib/utils_log.h
+++ b/raylib/utils_log.h
@@ -1,0 +1,11 @@
+#if defined(__cplusplus)
+extern "C" {            // Prevents name mangling of functions
+#endif
+
+
+void setLogCallbackWrapper(void);                 // enable the call-back
+void internalTraceLogCallbackGo(int, void*, int); // Go function that will get called
+
+#if defined(__cplusplus)
+}
+#endif


### PR DESCRIPTION
Hi, I've added a SetTraceLogCallback, including an example, with this we could get a callback and handle the trace log in go.

```go
	rl.SetTraceLogCallback(func(logType int, str string) {
		level := ""
		switch logType {
		case rl.LogDebug:
			level = "Debug"
		case rl.LogError:
			level = "Error"
		case rl.LogInfo:
			level = "Info"
		case rl.LogTrace:
			level = "Trace"
		case rl.LogWarning:
			level = "Warning"
		case rl.LogFatal:
			level = "Fatal"
		}
		if logType != rl.LogFatal {
			log.Printf("%s - %s", level, str)
		} else {
			log.Fatalf("%s - %s", level, str)
		}
	})
```
This allow to use your favourite go logger implementation such as https://github.com/sirupsen/logrus or others.

**Details:**

I've created 2 C Files that wrap the callback format a call a Go function, see:

https://github.com/juan-medina/raylib-go/blob/ca72d271e15947771e228e2db7cd56a45c2913f9/raylib/utils_log.h
https://github.com/juan-medina/raylib-go/blob/ca72d271e15947771e228e2db7cd56a45c2913f9/raylib/utils_log.c

Them a Go file that calls the functions and gets call back

https://github.com/juan-medina/raylib-go/blob/ca72d271e15947771e228e2db7cd56a45c2913f9/raylib/utils_log.go

**Full Example:**

https://github.com/juan-medina/raylib-go/blob/ca72d271e15947771e228e2db7cd56a45c2913f9/examples/utils/utils.go

**Note:**

The build is failing because the example use the new function that off course is not yet available since is not yet merged, but clone the repo and you will see it working.
