### PR TITLE
add GetCharPressed

### DIFF
--- a/raylib/core.go
+++ b/raylib/core.go
@@ -647,6 +647,13 @@ func GetKeyPressed() int32 {
 	return v
 }
 
+// GetCharPressed - Get the last char pressed
+func GetCharPressed() int32 {
+	ret := C.GetCharPressed()
+	v := (int32)(ret)
+	return v
+}
+
 // SetExitKey - Set a custom key to exit program (default is ESC)
 func SetExitKey(key int32) {
 	ckey := (C.int)(key)


### PR DESCRIPTION
After updating the C source, GetKeyPressed returns the keycode instead of the char as always (read https://github.com/raysan5/raylib/commit/96542269d0ad8f7be9cfb4f0e9d02df2c45703ff for more).

This PR adds the `GetCharPressed` binding function which allows to retrieve the char instead of the keycode.