### PR TITLE
Added ImageDrawLine and ImageDrawLineV functions to rtexture.go

### DIFF
--- a/raylib/rtextures.go
+++ b/raylib/rtextures.go
@@ -384,6 +384,28 @@ func ImageDraw(dst, src *Image, srcRec, dstRec Rectangle, tint color.RGBA) {
 	C.ImageDraw(cdst, *csrc, *csrcRec, *cdstRec, *ctint)
 }
 
+// ImageDrawLine - Draw line within an image
+func ImageDrawLine(dst *Image, startPosX, startPosY, endPosX, endPosY int32, col color.RGBA) {
+	cdst := dst.cptr()
+	cstartPosX := (C.int)(startPosX)
+	cstartPosY := (C.int)(startPosY)
+	cendPosX := (C.int)(endPosX)
+	cendPosY := (C.int)(endPosY)
+	ccolor := colorCptr(col)
+	C.ImageDrawLine(cdst, cstartPosX, cstartPosY, cendPosX, cendPosY, ccolor)
+}
+
+// ImageDrawLineV - Draw line within an image, vector version
+func ImageDrawLineV(dst *Image, startPosX, startPosY, endPosX, endPosY int32, col color.RGBA) {
+	cdst := dst.cptr()
+	cstartPosX := (C.int)(startPosX)
+	cstartPosY := (C.int)(startPosY)
+	cendPosX := (C.int)(endPosX)
+	cendPosY := (C.int)(endPosY)
+	ccolor := colorCptr(col)
+	C.ImageDrawLineV(cdst, cstartPosX, cstartPosY, cendPosX, cendPosY, ccolor)
+}
+
 // ImageDrawCircle - Draw a filled circle within an image
 func ImageDrawCircle(dst *Image, centerX, centerY, radius int32, col color.RGBA) {
 	cdst := dst.cptr()

--- a/raylib/rtextures.go
+++ b/raylib/rtextures.go
@@ -392,18 +392,16 @@ func ImageDrawLine(dst *Image, startPosX, startPosY, endPosX, endPosY int32, col
 	cendPosX := (C.int)(endPosX)
 	cendPosY := (C.int)(endPosY)
 	ccolor := colorCptr(col)
-	C.ImageDrawLine(cdst, cstartPosX, cstartPosY, cendPosX, cendPosY, ccolor)
+	C.ImageDrawLine(cdst, cstartPosX, cstartPosY, cendPosX, cendPosY, *ccolor)
 }
 
 // ImageDrawLineV - Draw line within an image, vector version
-func ImageDrawLineV(dst *Image, startPosX, startPosY, endPosX, endPosY int32, col color.RGBA) {
+func ImageDrawLineV(dst *Image, start, end Vector2, col color.RGBA) {
 	cdst := dst.cptr()
-	cstartPosX := (C.int)(startPosX)
-	cstartPosY := (C.int)(startPosY)
-	cendPosX := (C.int)(endPosX)
-	cendPosY := (C.int)(endPosY)
+	cstart := start.cptr()
+	cend := end.cptr()
 	ccolor := colorCptr(col)
-	C.ImageDrawLineV(cdst, cstartPosX, cstartPosY, cendPosX, cendPosY, ccolor)
+	C.ImageDrawLineV(cdst, *cstart, *cend, *ccolor)
 }
 
 // ImageDrawCircle - Draw a filled circle within an image


### PR DESCRIPTION
Hi there, I was playing around with the binding trying to generate an image without opening a window and I noticed these two functions were missing; so I went ahead and added them since the binding seems straightforward enough. Please point out if anything is not quite right :slightly_smiling_face: 