### PR TITLE
Fixed GetFPS return type

### DIFF
--- a/raylib/rcore.go
+++ b/raylib/rcore.go
@@ -478,9 +478,9 @@ func SetTargetFPS(fps int32) {
 }
 
 // GetFPS - Returns current FPS
-func GetFPS() float32 {
+func GetFPS() int32 {
 	ret := C.GetFPS()
-	v := (float32)(ret)
+	v := (int32)(ret)
 	return v
 }
 


### PR DESCRIPTION
GetFPS function now returns an int32 to mirror C version of raylib (https://github.com/raysan5/raylib/blob/master/src/rcore.c)