### PR TITLE
Adding FreeBSD support

### DIFF
--- a/raylib/cgo_freebsd.go
+++ b/raylib/cgo_freebsd.go
@@ -36,7 +36,7 @@ package rl
 #cgo freebsd CFLAGS: -I/usr/local/include -Iexternal/glfw/include -DPLATFORM_DESKTOP
 #cgo freebsd LDFLAGS: -L/usr/local/lib
 
-#cgo freensd,!wayland LDFLAGS: -lGL -lm -pthread -ldl -lrt -lX11
+#cgo freebsd,!wayland LDFLAGS: -lGL -lm -pthread -ldl -lrt -lX11
 #cgo freebsd,wayland LDFLAGS: -lGL -lm -pthread -ldl -lrt -lwayland-client -lwayland-cursor -lwayland-egl -lxkbcommon
 
 #cgo freebsd,!wayland CFLAGS: -D_GLFW_X11

--- a/raylib/cgo_freebsd.go
+++ b/raylib/cgo_freebsd.go
@@ -1,0 +1,50 @@
+//go:build freebsd && !linux && !drm && !rpi && !android
+// +build freebsd,!linux,!drm,!rpi,!android
+
+package rl
+
+/*
+#include "external/glfw/src/context.c"
+#include "external/glfw/src/init.c"
+#include "external/glfw/src/input.c"
+#include "external/glfw/src/monitor.c"
+#include "external/glfw/src/platform.c"
+#include "external/glfw/src/vulkan.c"
+#include "external/glfw/src/window.c"
+
+#ifdef _GLFW_WAYLAND
+#include "external/glfw/src/wl_init.c"
+#include "external/glfw/src/wl_monitor.c"
+#include "external/glfw/src/wl_window.c"
+#endif
+#ifdef _GLFW_X11
+#include "external/glfw/src/x11_init.c"
+#include "external/glfw/src/x11_monitor.c"
+#include "external/glfw/src/x11_window.c"
+#include "external/glfw/src/glx_context.c"
+#endif
+
+#include "external/glfw/src/null_joystick.c"
+#include "external/glfw/src/posix_module.c"
+#include "external/glfw/src/posix_poll.c"
+#include "external/glfw/src/posix_thread.c"
+#include "external/glfw/src/posix_time.c"
+#include "external/glfw/src/xkb_unicode.c"
+#include "external/glfw/src/egl_context.c"
+#include "external/glfw/src/osmesa_context.c"
+
+#cgo freebsd CFLAGS: -I/usr/local/include -Iexternal/glfw/include -DPLATFORM_DESKTOP
+#cgo freebsd LDFLAGS: -L/usr/local/lib
+
+#cgo freensd,!wayland LDFLAGS: -lGL -lm -pthread -ldl -lrt -lX11
+#cgo freebsd,wayland LDFLAGS: -lGL -lm -pthread -ldl -lrt -lwayland-client -lwayland-cursor -lwayland-egl -lxkbcommon
+
+#cgo freebsd,!wayland CFLAGS: -D_GLFW_X11
+#cgo freebsd,wayland CFLAGS: -D_GLFW_WAYLAND
+
+#cgo freebsd,opengl11 CFLAGS: -DGRAPHICS_API_OPENGL_11
+#cgo freebsd,opengl21 CFLAGS: -DGRAPHICS_API_OPENGL_21
+#cgo freebsd,opengl43 CFLAGS: -DGRAPHICS_API_OPENGL_43
+#cgo freebsd,!opengl11,!opengl21,!opengl43 CFLAGS: -DGRAPHICS_API_OPENGL_33
+*/
+import "C"


### PR DESCRIPTION
Basically I just copied the `cgo_linux.go` to `cgo_freebsd.go` and added two new flags `-I/usr/local/include` and `-L/usr/local/lib` and had to remove `-Wno-stringop-overflow` (clang doesn't know this parameter).

FreeBSD stores header files and libraries in `/usr/local/*`. 

Also had to change `linux_joystick.c` to `null_joystick.c`. GLFW currently doesn't support gamepads: https://github.com/glfw/glfw/issues/1892

With that, I got it to run with clang (which is the default cgo compiler on FreeBSD) and gcc as well.