### PR TITLE
Update cgo_freebsd.go

### DIFF
--- a/raylib/cgo_freebsd.go
+++ b/raylib/cgo_freebsd.go
@@ -33,7 +33,7 @@ package rl
 #include "external/glfw/src/egl_context.c"
 #include "external/glfw/src/osmesa_context.c"
 
-#cgo freebsd CFLAGS: -I/usr/local/include -Iexternal/glfw/include -DPLATFORM_DESKTOP
+#cgo freebsd CFLAGS: -I. -I/usr/local/include -Iexternal/glfw/include -DPLATFORM_DESKTOP
 #cgo freebsd LDFLAGS: -L/usr/local/lib
 
 #cgo freebsd,!wayland LDFLAGS: -lGL -lm -pthread -ldl -lrt -lX11


### PR DESCRIPTION
The dynamic linked library of raylib is available via FreeBSD's package manger: https://www.freebsd.org/cgi/ports.cgi?query=raylib&stype=all

If installed, clang does moan, because it's using the header files from raylib and not raylib-go. 

To get around this, I had to add this flag:
`#cgo freebsd CFLAGS: -I.`