### PR TITLE
Typo in  rl.HomeDir()

### DIFF
--- a/raylib/utils.go
+++ b/raylib/utils.go
@@ -36,7 +36,7 @@ func TraceLog(logLevel TraceLogLevel, text string, v ...interface{}) {
 // HomeDir - Returns user home directory
 // NOTE: On Android this returns internal data path and must be called after InitWindow
 func HomeDir() string {	
-	if homeDir, err := os.UserHomeDir(); err != nil {
+	if homeDir, err := os.UserHomeDir(); err == nil {
 		return homeDir
 	}
 	return ""


### PR DESCRIPTION
There was a typo in utils.go `rl.HomeDir()`.
The function returned a blank string if there was no error.