### PR TITLE
OpenBSD support added

### DIFF
--- a/raylib/cgo_openbsd.go
+++ b/raylib/cgo_openbsd.go
@@ -1,0 +1,50 @@
+//go:build openbsd && !linux && !drm && !rpi && !android
+// +build openbsd,!linux,!drm,!rpi,!android
+
+package rl
+
+/*
+#include "external/glfw/src/context.c"
+#include "external/glfw/src/init.c"
+#include "external/glfw/src/input.c"
+#include "external/glfw/src/monitor.c"
+#include "external/glfw/src/platform.c"
+#include "external/glfw/src/vulkan.c"
+#include "external/glfw/src/window.c"
+
+#ifdef _GLFW_WAYLAND
+#include "external/glfw/src/wl_init.c"
+#include "external/glfw/src/wl_monitor.c"
+#include "external/glfw/src/wl_window.c"
+#endif
+#ifdef _GLFW_X11
+#include "external/glfw/src/x11_init.c"
+#include "external/glfw/src/x11_monitor.c"
+#include "external/glfw/src/x11_window.c"
+#include "external/glfw/src/glx_context.c"
+#endif
+
+#include "external/glfw/src/null_joystick.c"
+#include "external/glfw/src/posix_module.c"
+#include "external/glfw/src/posix_poll.c"
+#include "external/glfw/src/posix_thread.c"
+#include "external/glfw/src/posix_time.c"
+#include "external/glfw/src/xkb_unicode.c"
+#include "external/glfw/src/egl_context.c"
+#include "external/glfw/src/osmesa_context.c"
+
+#cgo openbsd CFLAGS: -I. -I/usr/X11R6/include -Iexternal/glfw/include -DPLATFORM_DESKTOP
+#cgo openbsd LDFLAGS: -L/usr/X11R6/lib
+
+#cgo openbsd,!wayland LDFLAGS: -lGL -lm -pthread -lX11
+#cgo openbsd,wayland LDFLAGS: -lGL -lm -pthread -lwayland-client -lwayland-cursor -lwayland-egl -lxkbcommon
+
+#cgo openbsd,!wayland CFLAGS: -D_GLFW_X11
+#cgo openbsd,wayland CFLAGS: -D_GLFW_WAYLAND
+
+#cgo openbsd,opengl11 CFLAGS: -DGRAPHICS_API_OPENGL_11
+#cgo openbsd,opengl21 CFLAGS: -DGRAPHICS_API_OPENGL_21
+#cgo openbsd,opengl43 CFLAGS: -DGRAPHICS_API_OPENGL_43
+#cgo openbsd,!opengl11,!opengl21,!opengl43 CFLAGS: -DGRAPHICS_API_OPENGL_33
+*/
+import "C"


### PR DESCRIPTION
X11 libs and headers a located in `/usr/X11R6/lib` and `/usr/X11R6/include`

Also had to remove `-ldl` and `-lrt`: https://www.openbsd.org/faq/ports/guide.html
_OpenBSD does NOT require -lcrypt, -ldl, or -lrt. The functions provided by these libraries are part of libc. The crypt() function does not support DES, only bcrypt._ 

I successfully tested it on OpenBSD  7.2 with X11 and the default  window manager fvwm.