### PR TITLE
Allow non-ascii characters in textbox

### DIFF
--- a/raygui/textbox.go
+++ b/raygui/textbox.go
@@ -3,6 +3,7 @@ package raygui
 import (
 	"fmt"
 	"time"
+	"unicode/utf8"
 
 	rl "github.com/gen2brain/raylib-go/raylib"
 )
@@ -29,11 +30,9 @@ func TextBox(bounds rl.Rectangle, text string) string {
 		borderColor = ToggleActiveBorderColor
 
 		framesCounter2++
-		letter = rl.GetKeyPressed()
-		if letter != -1 {
-			if letter >= 32 && letter < 127 {
-				text = fmt.Sprintf("%s%c", text, letter)
-			}
+		letter = rl.GetCharPressed()
+		if letter != -1 && letter >= 32 {
+			text = fmt.Sprintf("%s%c", text, letter)
 		}
 
 		backspacing := rl.IsKeyPressed(rl.KeyBackspace)
@@ -46,7 +45,8 @@ func TextBox(bounds rl.Rectangle, text string) string {
 			}
 		}
 		if backspacing && len(text) > 0 {
-			text = text[:len(text)-1]
+			_, size := utf8.DecodeLastRuneInString(text)
+			text = text[:len(text)-size]
 		}
 	}
 


### PR DESCRIPTION
Using the `GetKeyPressed()` function limits the character set that can be used. Using the `GetCharPressed()` function takes care of non-ascii characters pretty well.

Backspace functionality was broken with the above changes as removing the last "character" from the string would leave multi-byte characters broken. Using the Go built-in `utf8.DecodeLastRuneInString()` returns the size of the last "character".