### PR TITLE
Fix texture2d as it is deprecated name

### DIFF
--- a/examples/shaders/custom_uniform/glsl330/swirl.fs
+++ b/examples/shaders/custom_uniform/glsl330/swirl.fs
@@ -11,8 +11,6 @@ uniform vec4 colDiffuse;
 // Output fragment color
 out vec4 finalColor;
 
-// NOTE: Add here your custom variables
-
 // NOTE: Render size values should be passed from code
 const float renderWidth = 800;
 const float renderHeight = 450;
@@ -20,6 +18,7 @@ const float renderHeight = 450;
 float radius = 250.0;
 float angle = 0.8;
 
+// NOTE: center is connected to the golang code
 uniform vec2 center = vec2(200.0, 200.0);
 
 void main()
@@ -41,7 +40,7 @@ void main()
     }
 
     tc += center;
-    vec4 color = texture2D(texture0, tc/texSize)*colDiffuse*fragColor;;
+    vec4 color = texture(texture0, tc/texSize)*colDiffuse*fragColor;;
 
     finalColor = vec4(color.rgb, 1.0);;
 }

--- a/examples/shaders/custom_uniform/main.go
+++ b/examples/shaders/custom_uniform/main.go
@@ -31,6 +31,9 @@ func main() {
 	// Get variable (uniform) location on the shader to connect with the program
 	// NOTE: If uniform variable could not be found in the shader, function returns -1
 	swirlCenterLoc := rl.GetShaderLocation(shader, "center")
+	if swirlCenterLoc == -1 {
+		println("Warning: [SHDR] Swirl Center uniform not found on shader")
+	}
 
 	swirlCenter := make([]float32, 2)
 	swirlCenter[0] = float32(screenWidth) / 2

--- a/examples/shaders/postprocessing/glsl330/sobel.fs
+++ b/examples/shaders/postprocessing/glsl330/sobel.fs
@@ -20,22 +20,22 @@ void main()
     float y = 1.0/resolution.y;
     
     vec4 horizEdge = vec4(0.0);
-    horizEdge -= texture2D(texture0, vec2(fragTexCoord.x - x, fragTexCoord.y - y))*1.0;
-    horizEdge -= texture2D(texture0, vec2(fragTexCoord.x - x, fragTexCoord.y    ))*2.0;
-    horizEdge -= texture2D(texture0, vec2(fragTexCoord.x - x, fragTexCoord.y + y))*1.0;
-    horizEdge += texture2D(texture0, vec2(fragTexCoord.x + x, fragTexCoord.y - y))*1.0;
-    horizEdge += texture2D(texture0, vec2(fragTexCoord.x + x, fragTexCoord.y    ))*2.0;
-    horizEdge += texture2D(texture0, vec2(fragTexCoord.x + x, fragTexCoord.y + y))*1.0;
+    horizEdge -= texture(texture0, vec2(fragTexCoord.x - x, fragTexCoord.y - y))*1.0;
+    horizEdge -= texture(texture0, vec2(fragTexCoord.x - x, fragTexCoord.y    ))*2.0;
+    horizEdge -= texture(texture0, vec2(fragTexCoord.x - x, fragTexCoord.y + y))*1.0;
+    horizEdge += texture(texture0, vec2(fragTexCoord.x + x, fragTexCoord.y - y))*1.0;
+    horizEdge += texture(texture0, vec2(fragTexCoord.x + x, fragTexCoord.y    ))*2.0;
+    horizEdge += texture(texture0, vec2(fragTexCoord.x + x, fragTexCoord.y + y))*1.0;
     
     vec4 vertEdge = vec4(0.0);
-    vertEdge -= texture2D(texture0, vec2(fragTexCoord.x - x, fragTexCoord.y - y))*1.0;
-    vertEdge -= texture2D(texture0, vec2(fragTexCoord.x    , fragTexCoord.y - y))*2.0;
-    vertEdge -= texture2D(texture0, vec2(fragTexCoord.x + x, fragTexCoord.y - y))*1.0;
-    vertEdge += texture2D(texture0, vec2(fragTexCoord.x - x, fragTexCoord.y + y))*1.0;
-    vertEdge += texture2D(texture0, vec2(fragTexCoord.x    , fragTexCoord.y + y))*2.0;
-    vertEdge += texture2D(texture0, vec2(fragTexCoord.x + x, fragTexCoord.y + y))*1.0;
+    vertEdge -= texture(texture0, vec2(fragTexCoord.x - x, fragTexCoord.y - y))*1.0;
+    vertEdge -= texture(texture0, vec2(fragTexCoord.x    , fragTexCoord.y - y))*2.0;
+    vertEdge -= texture(texture0, vec2(fragTexCoord.x + x, fragTexCoord.y - y))*1.0;
+    vertEdge += texture(texture0, vec2(fragTexCoord.x - x, fragTexCoord.y + y))*1.0;
+    vertEdge += texture(texture0, vec2(fragTexCoord.x    , fragTexCoord.y + y))*2.0;
+    vertEdge += texture(texture0, vec2(fragTexCoord.x + x, fragTexCoord.y + y))*1.0;
     
     vec3 edge = sqrt((horizEdge.rgb*horizEdge.rgb) + (vertEdge.rgb*vertEdge.rgb));
     
-    finalColor = vec4(edge, texture2D(texture0, fragTexCoord).a);
+    finalColor = vec4(edge, texture(texture0, fragTexCoord).a);
 }


### PR DESCRIPTION
In this PR my intent is to rename `texture2d()` to `texture()` to fix shader compilation errors on mac. `texture2d()` is deprecated and only compiles if compatibility profiles are implemented. 