### PR TITLE
rename SetTraceLog to SetTraceLogLevel

### DIFF
--- a/raylib/utils.go
+++ b/raylib/utils.go
@@ -19,13 +19,13 @@ import (
 	"unsafe"
 )
 
-// Set the current threshold (minimum) log level
+// SetTraceLogLevel - Set the current threshold (minimum) log level
 func SetTraceLogLevel(logLevel TraceLogLevel) {
 	clogLevel := (C.int)(logLevel)
 	C.SetTraceLogLevel(clogLevel)
 }
 
-// Show trace log messages (LOG_DEBUG, LOG_INFO, LOG_WARNING, LOG_ERROR...)
+// TraceLog - Show trace log messages (LOG_DEBUG, LOG_INFO, LOG_WARNING, LOG_ERROR...)
 func TraceLog(logLevel TraceLogLevel, text string, v ...interface{}) {
 	ctext := C.CString(fmt.Sprintf(text, v...))
 	defer C.free(unsafe.Pointer(ctext))

--- a/raylib/utils.go
+++ b/raylib/utils.go
@@ -20,7 +20,7 @@ import (
 )
 
 // Set the current threshold (minimum) log level
-func SetTraceLog(logLevel TraceLogLevel) {
+func SetTraceLogLevel(logLevel TraceLogLevel) {
 	clogLevel := (C.int)(logLevel)
 	C.SetTraceLogLevel(clogLevel)
 }

--- a/raylib/utils_android.go
+++ b/raylib/utils_android.go
@@ -18,13 +18,13 @@ import (
 	"unsafe"
 )
 
-// Set the current threshold (minimum) log level
+// SetTraceLogLevel - Set the current threshold (minimum) log level
 func SetTraceLogLevel(logLevel TraceLogLevel) {
 	clogLevel := (C.int)(logLevel)
 	C.SetTraceLogLevel(clogLevel)
 }
 
-// Show trace log messages (LOG_DEBUG, LOG_INFO, LOG_WARNING, LOG_ERROR...)
+// TraceLog - Show trace log messages (LOG_DEBUG, LOG_INFO, LOG_WARNING, LOG_ERROR...)
 func TraceLog(logLevel TraceLogLevel, text string, v ...interface{}) {
 	ctext := C.CString(fmt.Sprintf(text, v...))
 	defer C.free(unsafe.Pointer(ctext))

--- a/raylib/utils_android.go
+++ b/raylib/utils_android.go
@@ -19,7 +19,7 @@ import (
 )
 
 // Set the current threshold (minimum) log level
-func SetTraceLog(logLevel TraceLogLevel) {
+func SetTraceLogLevel(logLevel TraceLogLevel) {
 	clogLevel := (C.int)(logLevel)
 	C.SetTraceLogLevel(clogLevel)
 }


### PR DESCRIPTION
The C function in raylib is SetTraceLogLevel but in the go binding is SetTraceLog. I found this annoying so I have opened a pull request to fix it. If you want me to add other functions with the old name as well for backwards compatibility let me know. I just think that the Go API should match the C api. If you don't want to change this that's fine, then just close this PR.