### PR TITLE
bugfix: change raygui.SetStyle and raygui.GetStyle to use int64 for the value

### DIFF
--- a/raygui/raygui.go
+++ b/raygui/raygui.go
@@ -263,7 +263,7 @@ func GetState() int32 {
 }
 
 // GuiSetStyle .
-func SetStyle(control int32, property int32, value int32) {
+func SetStyle(control int32, property int32, value int64) {
 	ccontrol := C.int(control)
 	cproperty := C.int(property)
 	cvalue := C.int(value)
@@ -271,10 +271,10 @@ func SetStyle(control int32, property int32, value int32) {
 }
 
 // GuiGetStyle - Get one style property
-func GetStyle(control int32, property int32) int32 {
+func GetStyle(control int32, property int32) int64 {
 	ccontrol := C.int(control)
 	cproperty := C.int(property)
-	return int32(C.GuiGetStyle(ccontrol, cproperty))
+	return int64(C.GuiGetStyle(ccontrol, cproperty))
 }
 
 // GuiWindowBox - Window Box control, shows a window that can be closed


### PR DESCRIPTION
Hey!

When I tried to change the default text color to white using this:
```go
    rg.SetStyle(rg.DEFAULT, rg.TEXT_COLOR_NORMAL, 0xffffffff)
```
I ran into an NumericOverflow error. This happens because the integer represented by `0xffffffff` is above the maximum value for `int32` ("lower" colors like `0x707070ff` are fine).

I am guessing this is an oversight? If so, changing the golang intermediaries to use int64 for the value fixes this problem, allowing the text to be set to white.