### PR TITLE
Fixing TextBox issue and adding Trim to other inputs

### DIFF
--- a/raygui/raygui.go
+++ b/raygui/raygui.go
@@ -756,7 +756,7 @@ func TextBox(bounds rl.Rectangle, text *string, textSize int, editMode bool) boo
 	}
 	ctext := (*C.char)(unsafe.Pointer(&bs[0]))
 	defer func() {
-		*text = strings.TrimSpace( strings.Trim(string(bs), "\x00") )
+		*text = strings.TrimSpace(strings.Trim(string(bs), "\x00"))
 		// no need : C.free(unsafe.Pointer(ctext))
 	}()
 
@@ -1072,7 +1072,7 @@ func TextInputBox(bounds rl.Rectangle, title, message, buttons string, text *str
 	}
 	ctext := (*C.char)(unsafe.Pointer(&bs[0]))
 	defer func() {
-		*text = strings.TrimSpace( strings.Trim(string(bs), "\x00") )
+		*text = strings.TrimSpace(strings.Trim(string(bs), "\x00"))
 		// no need : C.free(unsafe.Pointer(ctext))
 	}()
 
@@ -1106,7 +1106,7 @@ func TextBoxMulti(bounds rl.Rectangle, text *string, textSize int32, editMode bo
 	}
 	ctext := (*C.char)(unsafe.Pointer(&bs[0]))
 	defer func() {
-		*text = strings.TrimSpace( strings.Trim(string(bs), "\x00") )
+		*text = strings.TrimSpace(strings.Trim(string(bs), "\x00"))
 		// no need : C.free(unsafe.Pointer(ctext))
 	}()
 

--- a/raygui/raygui.go
+++ b/raygui/raygui.go
@@ -751,12 +751,12 @@ func TextBox(bounds rl.Rectangle, text *string, textSize int, editMode bool) boo
 	if len(bs) == 0 {
 		bs = []byte{byte(0)}
 	}
-	//if 0 < len(bs) && bs[len(bs)-1] != byte(0) { // minimalize allocation
-	bs = append(bs, byte(0)) // for next input symbols
-	//}
+	if 0 < len(bs) && bs[len(bs)-1] != byte(0) { // minimalize allocation
+		bs = append(bs, byte(0)) // for next input symbols
+	}
 	ctext := (*C.char)(unsafe.Pointer(&bs[0]))
 	defer func() {
-		*text = strings.TrimSpace(string(bs))
+		*text = strings.TrimSpace( strings.Trim(string(bs), "\x00") )
 		// no need : C.free(unsafe.Pointer(ctext))
 	}()
 
@@ -1072,7 +1072,7 @@ func TextInputBox(bounds rl.Rectangle, title, message, buttons string, text *str
 	}
 	ctext := (*C.char)(unsafe.Pointer(&bs[0]))
 	defer func() {
-		*text = string(bs)
+		*text = strings.TrimSpace( strings.Trim(string(bs), "\x00") )
 		// no need : C.free(unsafe.Pointer(ctext))
 	}()
 
@@ -1106,7 +1106,7 @@ func TextBoxMulti(bounds rl.Rectangle, text *string, textSize int32, editMode bo
 	}
 	ctext := (*C.char)(unsafe.Pointer(&bs[0]))
 	defer func() {
-		*text = string(bs)
+		*text = strings.TrimSpace( strings.Trim(string(bs), "\x00") )
 		// no need : C.free(unsafe.Pointer(ctext))
 	}()
 


### PR DESCRIPTION
The TextBox widget on raygui was adding 0's to the end of the string indefinitely, so the string always grows in size. Fixed by removing the comments on the if statement that reduces allocation.

Also, included a Trim call to remove the 0's at the end of the string as it triggers erros when using this string with some go stdlib functinos.

Included the Trim calls missing on other text input widgets as well.