### PR TITLE
fix: rand.Seed is deprecated

### DIFF
--- a/examples/games/life/main.go
+++ b/examples/games/life/main.go
@@ -4,7 +4,7 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/gen2brain/raylib-go/raylib"
+	rl "github.com/gen2brain/raylib-go/raylib"
 )
 
 const (
@@ -32,7 +32,7 @@ type Game struct {
 }
 
 func main() {
-	rand.Seed(time.Now().UnixNano())
+	rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	game := Game{}
 	game.Init(false)


### PR DESCRIPTION
rand.Seed is deprecated as of Go 1.20, update accordingly to Go's documentation.