### PR TITLE
Fixing snake example fruit spawning

### DIFF
--- a/examples/games/snake/main.go
+++ b/examples/games/snake/main.go
@@ -160,15 +160,15 @@ func (g *Game) Update() {
 			if !g.Fruit.Active {
 				g.Fruit.Active = true
 				g.Fruit.Position = rl.NewVector2(
-					float32(rl.GetRandomValue(0, (g.ScreenWidth/squareSize)-1)*squareSize+int32(g.Offset.X)/2),
-					float32(rl.GetRandomValue(0, (g.ScreenHeight/squareSize)-1)*squareSize+int32(g.Offset.Y)/2),
+					float32(rl.GetRandomValue(0, (g.ScreenWidth/squareSize)-1)*squareSize)+(g.Offset.X)/2,
+					float32(rl.GetRandomValue(0, (g.ScreenHeight/squareSize)-1)*squareSize)+(g.Offset.Y)/2,
 				)
 
 				for i := 0; i < g.CounterTail; i++ {
 					for (g.Fruit.Position.X == g.Snake[i].Position.X) && (g.Fruit.Position.Y == g.Snake[i].Position.Y) {
 						g.Fruit.Position = rl.NewVector2(
-							float32(rl.GetRandomValue(0, (g.ScreenWidth/squareSize)-1)*squareSize),
-							float32(rl.GetRandomValue(0, (g.ScreenHeight/squareSize)-1)*squareSize),
+							float32(rl.GetRandomValue(0, (g.ScreenWidth/squareSize)-1)*squareSize)+g.Offset.X/2,
+							float32(rl.GetRandomValue(0, (g.ScreenHeight/squareSize)-1)*squareSize)+g.Offset.Y/2,
 						)
 						i = 0
 					}


### PR DESCRIPTION
The snake example does not follow the original [raylib example](https://github.com/raysan5/raylib-games/blob/5ceec7c117a7f96504d215c6e49335848c4f7b2a/classics/src/snake.c#L208C108-L208C108)

The original example uses floating coordinates for the snake and fruit positions (I'm not sure if this is intentional), while the current raylib-go example uses integer coordinates for fruit spawning. This causes the collision calculation to be inaccurate, resulting in a bug where the snake can eat the fruit even when it is to the left of it.






