### PR TITLE
Add UnloadImageColors

### DIFF
--- a/raylib/rtextures.go
+++ b/raylib/rtextures.go
@@ -166,6 +166,11 @@ func LoadImageColors(img *Image) []color.RGBA {
 	return (*[1 << 24]color.RGBA)(unsafe.Pointer(ret))[0 : img.Width*img.Height]
 }
 
+// UnloadImageColors - Unload color data loaded with LoadImageColors()
+func UnloadImageColors(cols []color.RGBA) {
+	C.UnloadImageColors((*C.Color)(unsafe.Pointer(&cols[0])))
+}
+
 // LoadImageFromTexture - Get pixel data from GPU texture and return an Image
 func LoadImageFromTexture(texture Texture2D) *Image {
 	ctexture := texture.cptr()


### PR DESCRIPTION
From the raylib docs, the returned Color list from LoadImageColors should be released with UnloadImageColors. Since the Go wrapper keeps the pointer to this data around (and wraps it into a Go slice), there needs to be a way to release the memory since the Go garbage collector will not properly dispose of the colors list and thus leak it. 

I noticed this issue when calling LoadImageColors in the gameloop causing memory to balloon. 

This could potentially be handled in the LoadImageColors function automatically with `runtime.SetFinalizer`. Thoughts?