### PR TITLE
Add flag for borderless windowed mode

### DIFF
--- a/raylib/raylib.go
+++ b/raylib/raylib.go
@@ -234,6 +234,8 @@ const (
 	FlagWindowHighdpi = 0x00002000
 	// Set to support mouse passthrough, only supported when FLAG_WINDOW_UNDECORATED
 	FlagWindowMousePassthrough = 0x00004000
+	// Set to run program in borderless windowed mode
+	FlagBorderlessWindowedMode = 0x00008000
 	// Set to try enabling MSAA 4X
 	FlagMsaa4xHint = 0x00000020
 	// Set to try enabling interlaced video format (for V3D)


### PR DESCRIPTION
This PR adds the flag for borderless windowed mode.
Currently you can set this flag using: `rl.SetWindowState(0x00008000)`
Just adding it to constants.