### PR TITLE
physics.GetBodies: return only non nil (active) bodies

### DIFF
--- a/physics/physics.go
+++ b/physics/physics.go
@@ -526,7 +526,7 @@ func Shatter(body *Body, position rl.Vector2, force float32) {
 
 // GetBodies - Returns the slice of created physics bodies
 func GetBodies() []*Body {
-	return bodies[:]
+	return bodies[:bodiesCount]
 }
 
 // GetBodiesCount - Returns the current amount of created physics bodies


### PR DESCRIPTION
Fixes #336 