### PR TITLE
add nixos build dependencies command to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ It is also possible to use raylib-go without cgo (Windows only; see requirements
 
     dnf install mesa-libGL-devel libXi-devel libXcursor-devel libXrandr-devel libXinerama-devel wayland-devel libxkbcommon-devel
 
+##### NixOS
+
+    nix-shell -p libGL xorg.libXi xorg.libXcursor xorg.libXrandr xorg.libXinerama wayland libxkbcommon
+
 ##### macOS
 
 On macOS you need Xcode or Command Line Tools for Xcode.


### PR DESCRIPTION
This pull request simply adds instructions on how to get the build dependencies on NixOS.
This might help NixOS beginners in the future and prevent issues like #267.