### PR TITLE
Added custom frame control functions to rcore.go

### DIFF
--- a/raylib/raylib_purego.go
+++ b/raylib/raylib_purego.go
@@ -1492,6 +1492,11 @@ func GetFPS() int32 {
 	return getFPS()
 }
 
+// Custom frame control functions
+// NOTE: SwapScreenBuffer and PollInputEvents are intended for advanced users that want full control over the frame processing
+// By default EndDrawing() does this job: draws everything + SwapScreenBuffer() + manage frame timing + PollInputEvents()
+// To avoid that behaviour and control frame processes manually you must recompile raylib with SUPPORT_CUSTOM_FRAME_CONTROL enabled in config.h
+
 // SwapScreenBuffer - Swap back buffer with front buffer (screen drawing)
 func SwapScreenBuffer() {
 	swapScreenBuffer()

--- a/raylib/rcore.go
+++ b/raylib/rcore.go
@@ -702,6 +702,22 @@ func GetTime() float64 {
 	return v
 }
 
+// Custom frame control functions
+// NOTE: SwapScreenBuffer and PollInputEvents are intended for advanced users that want full control over the frame processing
+// By default EndDrawing() does this job: draws everything + SwapScreenBuffer() + manage frame timing + PollInputEvents()
+// To avoid that behaviour and control frame processes manually you can either enable in config.h: SUPPORT_CUSTOM_FRAME_CONTROL
+// or add CGO_CFLAGS="-DSUPPORT_CUSTOM_FRAME_CONTROL=1" to your build
+
+// SwapScreenBuffer - Swap back buffer to front buffer
+func SwapScreenBuffer() {
+	C.SwapScreenBuffer()
+}
+
+// Register all input events
+func PollInputEvents() {
+	C.PollInputEvents()
+}
+
 // Fade - Returns color with alpha applied, alpha goes from 0.0f to 1.0f
 func Fade(col color.RGBA, alpha float32) color.RGBA {
 	ccolor := colorCptr(col)


### PR DESCRIPTION
Added `SwapScreenBuffer()` and `PollInputEvents` into rcore.go with corresponding comments.
To use them it's necessary to build with `CGO_CFLAGS="-DSUPPORT_CUSTOM_FRAME_CONTROL=1"`.
Also added more info in the raylib_purego.go file for theses two functions in order to inform that the dll must be recompiled