### PR TITLE
Expose ToggleBorderlessWindowed() to golang.

### DIFF
--- a/raylib/rcore.go
+++ b/raylib/rcore.go
@@ -217,6 +217,11 @@ func ToggleFullscreen() {
 	C.ToggleFullscreen()
 }
 
+// ToggleBorderlessWindowed - Borderless fullscreen toggle (only PLATFORM_DESKTOP)
+func ToggleBorderlessWindowed() {
+	C.ToggleBorderlessWindowed()
+}
+
 // MaximizeWindow - Set window state: maximized, if resizable
 func MaximizeWindow() {
 	C.MaximizeWindow()


### PR DESCRIPTION
Exposed existing `ToggleBorderlessWindowed()` function to golang side.

https://github.com/gen2brain/raylib-go/blob/f406ea403bc8762af8e9258a0feab83824e3467f/raylib/raylib.h#L968
https://github.com/gen2brain/raylib-go/blob/f406ea403bc8762af8e9258a0feab83824e3467f/raylib/platforms/rcore_desktop.c#L200

Tested it on my end using Windows but I have no experience working with bindings in golang. So not sure if there is more that needs to be done. If that's the case just let me know and I can add the work.