### PR TITLE
Improve raw audio example

### DIFF
--- a/examples/audio/raw_stream/main.go
+++ b/examples/audio/raw_stream/main.go
@@ -12,7 +12,7 @@ const (
 	maxSamples          = 6000
 	sampleRate          = 6000
 	maxSamplesPerUpdate = 1600
-	f                   = 440
+	frequency           = 440
 	targetFPS           = 240
 )
 
@@ -29,7 +29,7 @@ func main() {
 
 	for i := 0; i < maxSamples; i++ {
 		t := float32(i) / float32(maxSamples)
-		data[i] = float32(math.Sin(float64((2 * rl.Pi * f * t))))
+		data[i] = float32(math.Sin(float64((2 * rl.Pi * frequency * t))))
 	}
 
 	// NOTE: The buffer can only be updated when it has been processed.  Time between buffer processing and next load and causes clipping
@@ -55,7 +55,7 @@ func main() {
 
 		rl.BeginDrawing()
 		rl.ClearBackground(rl.RayWhite)
-		rl.DrawText(fmt.Sprintf("%d Hz SINE WAVE SHOULD BE PLAYING!", f), 200, 140, 20, rl.LightGray)
+		rl.DrawText(fmt.Sprintf("%d Hz SINE WAVE SHOULD BE PLAYING!", frequency), 200, 140, 20, rl.LightGray)
 
 		// NOTE: Draw a part of the sine wave (only screen width)
 		for i := 0; i < int(rl.GetScreenWidth()); i++ {

--- a/examples/audio/raw_stream/main.go
+++ b/examples/audio/raw_stream/main.go
@@ -63,7 +63,7 @@ func main() {
 		// NOTE: Draw a part of the sine wave (only screen width)
 		for i := 0; i < int(rl.GetScreenWidth()); i++ {
 			position.X = float32(i)
-			position.Y = 250 + 10*data[i]
+			position.Y = 250 + 10*data[i*nSamples/int(20*rl.GetScreenWidth())]
 
 			rl.DrawPixelV(position, rl.Red)
 		}

--- a/examples/audio/raw_stream/main.go
+++ b/examples/audio/raw_stream/main.go
@@ -18,13 +18,13 @@ const (
 
 func main() {
 	rl.InitWindow(800, 450, "raylib [audio] example - raw audio streaming")
-
+	position := rl.NewVector2(0, 0)
 	rl.InitAudioDevice()
 
 	// Init raw audio stream (sample rate: <maxSamples>, sample size: 32bit-float, channels: 1-mono)
 	stream := rl.LoadAudioStream(maxSamples, 32, 1)
 
-	//// Fill create sine wave to play
+	//// Create sine wave to play
 	data := make([]float32, maxSamples)
 
 	for i := 0; i < maxSamples; i++ {
@@ -32,18 +32,13 @@ func main() {
 		data[i] = float32(math.Sin(float64((2 * rl.Pi * f * t))))
 	}
 
-	// NOTE: The buffer can only be updated when it has been processed, so there is clipping in the time between
-	// buffer exhaustion and next load.
+	// NOTE: The buffer can only be updated when it has been processed.  Time between buffer processing and next load and causes clipping
 	rl.PlayAudioStream(stream)
 
-	position := rl.NewVector2(0, 0)
-
 	startTime := time.Now()
-
 	rl.SetTargetFPS(targetFPS)
 
 	for !rl.WindowShouldClose() {
-
 		// Refill audio stream if buffer is processed
 		if rl.IsAudioStreamProcessed(stream) {
 			elapsedTime := time.Since(startTime).Seconds()
@@ -52,18 +47,13 @@ func main() {
 
 			if nextSampleIndex > maxSamples {
 				nextSampleIndex = maxSamplesPerUpdate - (maxSamples - currentSampleIndex)
-				samplesToWrite := append(data[currentSampleIndex:], data[:nextSampleIndex]...)
-				rl.UpdateAudioStream(stream, samplesToWrite)
+				rl.UpdateAudioStream(stream, append(data[currentSampleIndex:], data[:nextSampleIndex]...))
 			} else {
-				samplesToWrite := data[currentSampleIndex:nextSampleIndex]
-				rl.UpdateAudioStream(stream, samplesToWrite)
+				rl.UpdateAudioStream(stream, data[currentSampleIndex:nextSampleIndex])
 			}
-
-			fmt.Printf("Writing samples from %d to %d \n", currentSampleIndex, nextSampleIndex)
 		}
 
 		rl.BeginDrawing()
-
 		rl.ClearBackground(rl.RayWhite)
 		rl.DrawText(fmt.Sprintf("%d Hz SINE WAVE SHOULD BE PLAYING!", f), 200, 140, 20, rl.LightGray)
 

--- a/examples/audio/raw_stream/main.go
+++ b/examples/audio/raw_stream/main.go
@@ -9,16 +9,19 @@ import (
 )
 
 const (
-	nSamples          = 6000
-	sampleRate        = 6000
-	nSamplesPerUpdate = 1400
-	frequency         = 440
-	targetFPS         = 240
+	nSamples   = 44000 * 10
+	sampleRate = 44000
+	bufferSize = nSamples
+	frequency  = 440
+	targetFPS  = 240
 )
 
 func main() {
 	rl.InitWindow(800, 450, "raylib [audio] example - raw audio streaming")
 	position := rl.NewVector2(0, 0)
+
+	rl.SetAudioStreamBufferSizeDefault(bufferSize)
+
 	rl.InitAudioDevice()
 
 	// Init raw audio stream (sample rate: <nSamples>, sample size: 32bit-float, channels: 1-mono)
@@ -43,10 +46,10 @@ func main() {
 		if rl.IsAudioStreamProcessed(stream) {
 			elapsedTime := time.Since(startTime).Seconds()
 			currentSampleIndex := int(math.Mod(elapsedTime*float64(sampleRate), float64(nSamples)))
-			nextSampleIndex := currentSampleIndex + nSamplesPerUpdate
+			nextSampleIndex := currentSampleIndex + bufferSize
 
 			if nextSampleIndex > nSamples {
-				nextSampleIndex = nSamplesPerUpdate - (nSamples - currentSampleIndex)
+				nextSampleIndex = bufferSize - (nSamples - currentSampleIndex)
 				rl.UpdateAudioStream(stream, append(data[currentSampleIndex:], data[:nextSampleIndex]...))
 			} else {
 				rl.UpdateAudioStream(stream, data[currentSampleIndex:nextSampleIndex])

--- a/examples/audio/raw_stream/main.go
+++ b/examples/audio/raw_stream/main.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	nSamples   = 44000 * 10
-	sampleRate = 44000
+	sampleRate = 6000
 	bufferSize = nSamples
 	frequency  = 440
 	targetFPS  = 240

--- a/examples/audio/raw_stream/main.go
+++ b/examples/audio/raw_stream/main.go
@@ -11,7 +11,7 @@ import (
 const (
 	nSamples          = 6000
 	sampleRate        = 6000
-	nSamplesPerUpdate = 1600
+	nSamplesPerUpdate = 1400
 	frequency         = 440
 	targetFPS         = 240
 )

--- a/examples/audio/raw_stream/main.go
+++ b/examples/audio/raw_stream/main.go
@@ -9,11 +9,11 @@ import (
 )
 
 const (
-	maxSamples          = 6000
-	sampleRate          = 6000
-	maxSamplesPerUpdate = 1600
-	frequency           = 440
-	targetFPS           = 240
+	nSamples          = 6000
+	sampleRate        = 6000
+	nSamplesPerUpdate = 1600
+	frequency         = 440
+	targetFPS         = 240
 )
 
 func main() {
@@ -21,14 +21,14 @@ func main() {
 	position := rl.NewVector2(0, 0)
 	rl.InitAudioDevice()
 
-	// Init raw audio stream (sample rate: <maxSamples>, sample size: 32bit-float, channels: 1-mono)
-	stream := rl.LoadAudioStream(maxSamples, 32, 1)
+	// Init raw audio stream (sample rate: <nSamples>, sample size: 32bit-float, channels: 1-mono)
+	stream := rl.LoadAudioStream(nSamples, 32, 1)
 
 	//// Create sine wave to play
-	data := make([]float32, maxSamples)
+	data := make([]float32, nSamples)
 
-	for i := 0; i < maxSamples; i++ {
-		t := float32(i) / float32(maxSamples)
+	for i := 0; i < nSamples; i++ {
+		t := float32(i) / float32(nSamples)
 		data[i] = float32(math.Sin(float64((2 * rl.Pi * frequency * t))))
 	}
 
@@ -42,11 +42,11 @@ func main() {
 		// Refill audio stream if buffer is processed
 		if rl.IsAudioStreamProcessed(stream) {
 			elapsedTime := time.Since(startTime).Seconds()
-			currentSampleIndex := int(math.Mod(elapsedTime*float64(sampleRate), float64(maxSamples)))
-			nextSampleIndex := currentSampleIndex + maxSamplesPerUpdate
+			currentSampleIndex := int(math.Mod(elapsedTime*float64(sampleRate), float64(nSamples)))
+			nextSampleIndex := currentSampleIndex + nSamplesPerUpdate
 
-			if nextSampleIndex > maxSamples {
-				nextSampleIndex = maxSamplesPerUpdate - (maxSamples - currentSampleIndex)
+			if nextSampleIndex > nSamples {
+				nextSampleIndex = nSamplesPerUpdate - (nSamples - currentSampleIndex)
 				rl.UpdateAudioStream(stream, append(data[currentSampleIndex:], data[:nextSampleIndex]...))
 			} else {
 				rl.UpdateAudioStream(stream, data[currentSampleIndex:nextSampleIndex])


### PR DESCRIPTION
The current raw audio example has some problems:

- updates to the audio stream attempt to write a larger slice of data than the buffer size
- the method of choosing which parts of the data to add to the buffer does not account well for the current progress of the played sine wave
- there are some magic numbers that could use explanation, like the sine wave parameters and `maxSamples`.  changing `maxSamples` can also cause the audio not to play


This PR addresses these problems:

- the maxSamplesPerUpdate is set to 1600 by default now.  This many samples can be safely added to the audio buffer
- Timedelta from the start of the program is used to determine the part of the sine wave data to load into the buffer whenever the buffer needs to be reloaded.  This is the most important change.  It makes the sound actually come out as a sine wave instead of un-aligned chunks of sine waves
- the raw sine wave is calculated with a frequency parameter to make things more clear
- code is refactored so the constants at the top of the file can all be changed independently without breaking the example