### PR TITLE
TraceLog and TraceLogCallback fixes

### DIFF
--- a/raylib/raylib_purego.go
+++ b/raylib/raylib_purego.go
@@ -1581,8 +1581,6 @@ func MemFree(ptr unsafe.Pointer) {
 }
 
 // SetTraceLogCallback - Set custom trace log
-//
-// REVIEW NEEDED! 2023-11-15 JupiterRider: The argument list paramter isn't impelmented yet.
 func SetTraceLogCallback(fn TraceLogCallbackFun) {
 	setTraceLogCallback(traceLogCallbackWrapper(fn))
 }

--- a/raylib/raylib_purego.go
+++ b/raylib/raylib_purego.go
@@ -4,6 +4,7 @@
 package rl
 
 import (
+	"fmt"
 	"image"
 	"image/color"
 	"os"
@@ -121,7 +122,7 @@ var unloadRandomSequence func(sequence *int32)
 var takeScreenshot func(fileName string)
 var setConfigFlags func(flags uint32)
 var openURL func(url string)
-var traceLog func(logLevel int32, text string, args ...any)
+var traceLog func(logLevel int32, text string)
 var setTraceLogLevel func(logLevel int32)
 var memAlloc func(size uint32) unsafe.Pointer
 var memRealloc func(ptr unsafe.Pointer, size uint32) unsafe.Pointer
@@ -1556,7 +1557,7 @@ func OpenURL(url string) {
 
 // TraceLog - Show trace log messages (LOG_DEBUG, LOG_INFO, LOG_WARNING, LOG_ERROR...)
 func TraceLog(logLevel TraceLogLevel, text string, args ...any) {
-	traceLog(int32(logLevel), text, args...)
+	traceLog(int32(logLevel), fmt.Sprintf(text, args...))
 }
 
 // SetTraceLogLevel - Set the current threshold (minimum) log level

--- a/raylib/utils_log.c
+++ b/raylib/utils_log.c
@@ -3,7 +3,7 @@
 #include <stdio.h>                      // Required for: vprintf()
 #include <string.h>                     // Required for: strcpy(), strcat()
 
-#define MAX_TRACELOG_BUFFER_SIZE   128  // As defined in utils.c from raylib
+#define MAX_TRACELOG_BUFFER_SIZE   256  // As defined in utils.c from raylib
 
 void rayLogWrapperCallback(int logType, const char *text, va_list args) {
 	char buffer[MAX_TRACELOG_BUFFER_SIZE] = { 0 };


### PR DESCRIPTION
- `TraceLog()` now uses fmt.Sprintf to match the cgo version
- The varargs are finally implemented for the TraceLogCallback function in purego. I used the wvsprintfA function for that. Microsoft advises to use other ones like for example StringCbVPrintfA, but they are not exported in any dll.