### PR TITLE
[raygui] don't trim leading and trailing white spaces (fix #351)

### DIFF
--- a/raygui/raygui.go
+++ b/raygui/raygui.go
@@ -970,7 +970,7 @@ func TextBox(bounds rl.Rectangle, text *string, textSize int, editMode bool) boo
 	}
 	ctext := (*C.char)(unsafe.Pointer(&bs[0]))
 	defer func() {
-		*text = strings.TrimSpace(strings.Trim(string(bs), "\x00"))
+		*text = strings.Trim(string(bs), "\x00")
 		// no need : C.free(unsafe.Pointer(ctext))
 	}()
 


### PR DESCRIPTION
I think it should be up to the user, if they want white spaces. c-raylib doesn't have this feature either.