### PR TITLE
Bump Go to 1.22

### DIFF
--- a/raylib/go.mod
+++ b/raylib/go.mod
@@ -1,6 +1,6 @@
 module github.com/gen2brain/raylib-go/raylib
 
-go 1.21
+go 1.22
 
 require (
 	github.com/ebitengine/purego v0.7.1


### PR DESCRIPTION
TBH not sure if this is OK, but `go build .` in raylib folder works and I wanted to use latest/greatest Go features, thanks