### PR TITLE
[rcore] Added MouseButton newtype

### DIFF
--- a/raylib/raylib.go
+++ b/raylib/raylib.go
@@ -366,9 +366,11 @@ const (
 	MouseMiddleButton = MouseButtonMiddle
 )
 
+type MouseButton int32
+
 // Mouse Buttons
 const (
-	MouseButtonLeft = iota
+	MouseButtonLeft MouseButton = iota
 	MouseButtonRight
 	MouseButtonMiddle
 	MouseButtonSide

--- a/raylib/raylib_purego.go
+++ b/raylib/raylib_purego.go
@@ -1757,23 +1757,23 @@ func SetGamepadMappings(mappings string) int32 {
 }
 
 // IsMouseButtonPressed - Check if a mouse button has been pressed once
-func IsMouseButtonPressed(button int32) bool {
-	return isMouseButtonPressed(button)
+func IsMouseButtonPressed(button MouseButton) bool {
+	return isMouseButtonPressed(int32(button))
 }
 
 // IsMouseButtonDown - Check if a mouse button is being pressed
-func IsMouseButtonDown(button int32) bool {
-	return isMouseButtonDown(button)
+func IsMouseButtonDown(button MouseButton) bool {
+	return isMouseButtonDown(int32(button))
 }
 
 // IsMouseButtonReleased - Check if a mouse button has been released once
-func IsMouseButtonReleased(button int32) bool {
-	return isMouseButtonReleased(button)
+func IsMouseButtonReleased(button MouseButton) bool {
+	return isMouseButtonReleased(int32(button))
 }
 
 // IsMouseButtonUp - Check if a mouse button is NOT being pressed
-func IsMouseButtonUp(button int32) bool {
-	return isMouseButtonUp(button)
+func IsMouseButtonUp(button MouseButton) bool {
+	return isMouseButtonUp(int32(button))
 }
 
 // GetMouseX - Get mouse position X

--- a/raylib/rcore.go
+++ b/raylib/rcore.go
@@ -1082,7 +1082,7 @@ func SetGamepadMappings(mappings string) int32 {
 }
 
 // IsMouseButtonPressed - Detect if a mouse button has been pressed once
-func IsMouseButtonPressed(button int32) bool {
+func IsMouseButtonPressed(button MouseButton) bool {
 	cbutton := (C.int)(button)
 	ret := C.IsMouseButtonPressed(cbutton)
 	v := bool(ret)
@@ -1090,7 +1090,7 @@ func IsMouseButtonPressed(button int32) bool {
 }
 
 // IsMouseButtonDown - Detect if a mouse button is being pressed
-func IsMouseButtonDown(button int32) bool {
+func IsMouseButtonDown(button MouseButton) bool {
 	cbutton := (C.int)(button)
 	ret := C.IsMouseButtonDown(cbutton)
 	v := bool(ret)
@@ -1098,7 +1098,7 @@ func IsMouseButtonDown(button int32) bool {
 }
 
 // IsMouseButtonReleased - Detect if a mouse button has been released once
-func IsMouseButtonReleased(button int32) bool {
+func IsMouseButtonReleased(button MouseButton) bool {
 	cbutton := (C.int)(button)
 	ret := C.IsMouseButtonReleased(cbutton)
 	v := bool(ret)
@@ -1106,7 +1106,7 @@ func IsMouseButtonReleased(button int32) bool {
 }
 
 // IsMouseButtonUp - Detect if a mouse button is NOT being pressed
-func IsMouseButtonUp(button int32) bool {
+func IsMouseButtonUp(button MouseButton) bool {
 	cbutton := (C.int)(button)
 	ret := C.IsMouseButtonUp(cbutton)
 	v := bool(ret)


### PR DESCRIPTION
Currently all the IsMouseButton* functions take in an int for the mouse button, which can be confusing for documentation reasons and has less type safety than if it used a newtype wrapper for int.

All I did is add a newtype & change the IsMouseButton functions accordingly.