### PR TITLE
Fix NewImageFromImage color converting

### DIFF
--- a/raylib/raylib_purego.go
+++ b/raylib/raylib_purego.go
@@ -3776,7 +3776,7 @@ func NewImageFromImage(img image.Image) *Image {
 		for x := 0; x < size.X; x++ {
 			col := img.At(x, y)
 			r, g, b, a := col.RGBA()
-			rcolor := NewColor(uint8(r), uint8(g), uint8(b), uint8(a))
+			rcolor := NewColor(uint8(r>>8), uint8(g>>8), uint8(b>>8), uint8(a>>8))
 			ImageDrawPixel(ret, int32(x), int32(y), rcolor)
 		}
 	}

--- a/raylib/rtextures.go
+++ b/raylib/rtextures.go
@@ -69,7 +69,7 @@ func NewImageFromImage(img image.Image) *Image {
 		for x := 0; x < size.X; x++ {
 			color := img.At(x, y)
 			r, g, b, a := color.RGBA()
-			rcolor := NewColor(uint8(r), uint8(g), uint8(b), uint8(a))
+			rcolor := NewColor(uint8(r>>8), uint8(g>>8), uint8(b>>8), uint8(a>>8))
 			ccolor = colorCptr(rcolor)
 
 			cx = (C.int)(x)


### PR DESCRIPTION
Old version of NewImageFromImage converted colors incorrectly.
Which was discussed  in #412.

It used to look like this.
```Go
rcolor := NewColor(uint8(r), uint8(g), uint8(b), uint8(a))
```
Now it looks this.
```Go
rcolor := NewColor(uint8(r>>8), uint8(g>>8), uint8(b>>8), uint8(a>>8))
```
Just like in go [image package](https://cs.opensource.google/go/go/+/refs/tags/go1.23.1:src/image/color/color.go;l=176).

Here's image demonstration.

Original jpeg image.
![saddie](https://github.com/user-attachments/assets/fbd56da4-5369-4ab4-b032-dc645d4de394)

Before
![broken-saddie](https://github.com/user-attachments/assets/4e135713-ad63-4ca3-a3bf-7a088b808fb5)

After
![fixed-saddie](https://github.com/user-attachments/assets/7d53f718-4263-47a3-a624-9f6ccca351cd)
