### PR TITLE
Added 'build-essential' as a requirement on ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ It is also possible to use raylib-go without cgo (Windows only; see requirements
 
 ##### Ubuntu
 
-    apt-get install libgl1-mesa-dev libxi-dev libxcursor-dev libxrandr-dev libxinerama-dev libwayland-dev libxkbcommon-dev
+    apt-get install libgl1-mesa-dev libxi-dev libxcursor-dev libxrandr-dev libxinerama-dev libwayland-dev libxkbcommon-dev build-essential
 
 ##### Fedora
 


### PR DESCRIPTION
I've had a fresh install of Kubuntu and for some reason that package was missing, maybe I removed it by mistake who knows. So when I tried to run the project I got errors like these:
 ./../go/pkg/mod/github.com/gen2brain/raylib-go/raylib/rcamera.go:196:27: undefined: GetMouseDelta

After installing build-essential this problem was solved, so it would be good to add it as the requirements because it can also happen to others and the errors aren't helpful.