### PR TITLE
Added a custom mesh to the example models/mesh_generation

### DIFF
--- a/examples/models/mesh_generation/main.go
+++ b/examples/models/mesh_generation/main.go
@@ -116,11 +116,11 @@ func main() {
 }
 
 func clearCustomMesh(model rl.Model) {
-	// Vertices, Normals and Texcoords of your custom mesh are Go slices.
+	// Vertices, Normals and Texcoords of your CUSTOM mesh are Go slices.
 	// UnloadModel calls UnloadMesh for every mesh and UnloadMesh tries
-	// to free your Go slices. The panic happens, because it cannot free
+	// to free your Go slices. This will panic because it cannot free
 	// Go slices. Free() is a C function and it expects to free C memory
-	// and not a Go slice.
+	// and not a Go slice. So clear the slices manually like this.
 	model.Meshes.Vertices = nil
 	model.Meshes.Normals = nil
 	model.Meshes.Texcoords = nil

--- a/examples/models/mesh_generation/main.go
+++ b/examples/models/mesh_generation/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"unsafe"
+
 	rl "github.com/gen2brain/raylib-go/raylib"
 )
 
@@ -8,7 +10,7 @@ func main() {
 	screenWidth := int32(1280)
 	screenHeight := int32(720)
 
-	numModels := 8
+	numModels := 9
 
 	rl.InitWindow(screenWidth, screenHeight, "raylib [models] example - mesh generation")
 
@@ -33,6 +35,7 @@ func main() {
 	models[5] = rl.LoadModelFromMesh(rl.GenMeshTorus(0.25, 4, 16, 32))
 	models[6] = rl.LoadModelFromMesh(rl.GenMeshKnot(1, 2, 16, 128))
 	models[7] = rl.LoadModelFromMesh(rl.GenMeshPoly(5, 2))
+	models[8] = rl.LoadModelFromMesh(GenMeshCustom())
 
 	for i := 0; i < numModels; i++ {
 		rl.SetMaterialTexture(models[i].Materials, rl.MapDiffuse, texture)
@@ -49,12 +52,17 @@ func main() {
 		rl.UpdateCamera(&camera, rl.CameraOrbital)
 
 		if rl.IsKeyPressed(rl.KeyUp) {
-			currentModel++
-			if currentModel >= numModels {
-				currentModel = 0
-			}
+			currentModel = (currentModel + 1) % numModels // Cycle between the textures
 		}
-
+		if rl.IsKeyPressed(rl.KeyDown) {
+			// Adding numModels here is necessary to avoid a crash
+			// where the golang % (modulus) operator, doesn't work as
+			// one might expect for negative numbers.
+			currentModel = (currentModel + numModels - 1) % numModels // Cycle between the textures
+		}
+		if rl.IsMouseButtonPressed(rl.MouseButtonLeft) {
+			currentModel = (currentModel + 1) % numModels // Cycle between the textures
+		}
 		rl.BeginDrawing()
 
 		rl.ClearBackground(rl.RayWhite)
@@ -66,9 +74,10 @@ func main() {
 
 		rl.EndMode3D()
 
-		rl.DrawRectangle(10, 10, 310, 30, rl.Fade(rl.SkyBlue, 0.5))
-		rl.DrawRectangleLines(10, 10, 310, 30, rl.Fade(rl.DarkBlue, 0.5))
-		rl.DrawText("UP ARROW KEY TO CHANGE MODELS", 20, 20, 10, rl.Blue)
+		rl.DrawRectangle(10, 10, 310, 50, rl.Fade(rl.SkyBlue, 0.5))
+		rl.DrawRectangleLines(10, 10, 310, 50, rl.Fade(rl.DarkBlue, 0.5))
+		rl.DrawText("UP/DOWN ARROW KEY OR LEFT MOUSE", 20, 20, 10, rl.Blue)
+		rl.DrawText("BUTTON TO CHANGE MODELS", 20, 40, 10, rl.Blue)
 
 		txt := "PLANE"
 		switch currentModel {
@@ -86,6 +95,8 @@ func main() {
 			txt = "KNOT"
 		case 7:
 			txt = "POLY"
+		case 8:
+			txt = "Custom (triangle)"
 		}
 		txtlen := rl.MeasureText(txt, 20)
 		rl.DrawText(txt, screenWidth/2-txtlen/2, 10, 20, rl.DarkBlue)
@@ -94,9 +105,60 @@ func main() {
 	}
 
 	rl.UnloadTexture(texture)
+	clearCustomMesh(models)
 	for i := 0; i < numModels; i++ {
 		rl.UnloadModel(models[i])
 	}
 
 	rl.CloseWindow()
+}
+
+func clearCustomMesh(models []rl.Model) {
+	// For some reason the custom model
+	// (id = 8) panics when unloading it.
+	// So we clear the mesh for it manually
+	// here.
+	models[8].Meshes.Vertices = nil
+	models[8].Meshes.Normals = nil
+	models[8].Meshes.Texcoords = nil
+}
+
+// GenMeshCustom generates a simple triangle mesh from code
+func GenMeshCustom() rl.Mesh {
+	mesh := rl.Mesh{
+		TriangleCount: 1,
+		VertexCount:   3,
+	}
+
+	var vertices, normals, texcoords []float32
+
+	// 3 vertices
+	vertices = addCoord(vertices, 0, 0, 0)
+	vertices = addCoord(vertices, 1, 0, 2)
+	vertices = addCoord(vertices, 2, 0, 0)
+	mesh.Vertices = unsafe.SliceData(vertices)
+
+	// 3 normals
+	normals = addCoord(normals, 0, 1, 0)
+	normals = addCoord(normals, 0, 1, 0)
+	normals = addCoord(normals, 0, 1, 0)
+	mesh.Normals = unsafe.SliceData(normals)
+
+	// 3 texcoords
+	texcoords = addCoord(texcoords, 0, 0)
+	texcoords = addCoord(texcoords, 0.5, 1)
+	texcoords = addCoord(texcoords, 1, 0)
+	mesh.Texcoords = unsafe.SliceData(texcoords)
+
+	// Upload mesh data from CPU (RAM) to GPU (VRAM) memory
+	rl.UploadMesh(&mesh, false)
+
+	return mesh
+}
+
+func addCoord(slice []float32, values ...float32) []float32 {
+	for _, value := range values {
+		slice = append(slice, value)
+	}
+	return slice
 }

--- a/examples/models/mesh_generation/main.go
+++ b/examples/models/mesh_generation/main.go
@@ -105,22 +105,28 @@ func main() {
 	}
 
 	rl.UnloadTexture(texture)
-	clearCustomMesh(models)
+	clearCustomMesh(models[8])
 	for i := 0; i < numModels; i++ {
+		//if i == 8 {
+		//meshes := unsafe.Slice(models[i].Meshes, models[i].MeshCount)
+		//for m := range meshes {
+		//	rl.UnloadMesh(&meshes[m])
+		//}
+		//}
 		rl.UnloadModel(models[i])
 	}
 
 	rl.CloseWindow()
 }
 
-func clearCustomMesh(models []rl.Model) {
+func clearCustomMesh(model rl.Model) {
 	// For some reason the custom model
 	// (id = 8) panics when unloading it.
 	// So we clear the mesh for it manually
 	// here.
-	models[8].Meshes.Vertices = nil
-	models[8].Meshes.Normals = nil
-	models[8].Meshes.Texcoords = nil
+	model.Meshes.Vertices = nil
+	model.Meshes.Normals = nil
+	model.Meshes.Texcoords = nil
 }
 
 // GenMeshCustom generates a simple triangle mesh from code

--- a/examples/models/mesh_generation/main.go
+++ b/examples/models/mesh_generation/main.go
@@ -105,14 +105,10 @@ func main() {
 	}
 
 	rl.UnloadTexture(texture)
+	// Custom models meshes needs to be
+	// cleared manually
 	clearCustomMesh(models[8])
 	for i := 0; i < numModels; i++ {
-		//if i == 8 {
-		//meshes := unsafe.Slice(models[i].Meshes, models[i].MeshCount)
-		//for m := range meshes {
-		//	rl.UnloadMesh(&meshes[m])
-		//}
-		//}
 		rl.UnloadModel(models[i])
 	}
 
@@ -120,10 +116,11 @@ func main() {
 }
 
 func clearCustomMesh(model rl.Model) {
-	// For some reason the custom model
-	// (id = 8) panics when unloading it.
-	// So we clear the mesh for it manually
-	// here.
+	// Vertices, Normals and Texcoords of your custom mesh are Go slices.
+	// UnloadModel calls UnloadMesh for every mesh and UnloadMesh tries
+	// to free your Go slices. The panic happens, because it cannot free
+	// Go slices. Free() is a C function and it expects to free C memory
+	// and not a Go slice.
 	model.Meshes.Vertices = nil
 	model.Meshes.Normals = nil
 	model.Meshes.Texcoords = nil


### PR DESCRIPTION
This [example at raylib.com](https://www.raylib.com/examples/models/loader.html?name=models_mesh_generation) has a custom mesh, which was missing in the golang example. So I added it...

However, the program panics when unloading the custom model. So I had to create the following function to clear the mesh before calling unload, and now it **does not panic**. 

I don't know if this is something that I don't understand, or if it is because of some underlying problem in the `Mesh` type, or `UnloadModel` function? Someone who knows more about the C code than me, might want to take a look at that.

```
func clearCustomMesh(models []rl.Model) {
	// For some reason the custom model
	// (id = 8) panics when unloading it.
	// So we clear the mesh for it manually
	// here.
	models[8].Meshes.Vertices = nil
	models[8].Meshes.Normals = nil
	models[8].Meshes.Texcoords = nil
}
```