### PR TITLE
rcore_desktop_rgfw.c SetGamepadVibration added

### DIFF
--- a/raylib/platforms/rcore_desktop_rgfw.c
+++ b/raylib/platforms/rcore_desktop_rgfw.c
@@ -783,6 +783,12 @@ int SetGamepadMappings(const char *mappings)
     return 0;
 }
 
+// Set gamepad vibration
+void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor, float duration)
+{
+    TRACELOG(LOG_WARNING, "GamepadSetVibration() not available on target platform");
+}
+
 // Set mouse position XY
 void SetMousePosition(int x, int y)
 {


### PR DESCRIPTION
When building with `-tags=rgfw` its said: `undefined reference to SetGamepadVibration`