### PR TITLE
Add return value to `LoadTextureDepth`

### DIFF
--- a/raylib/rlgl_cgo.go
+++ b/raylib/rlgl_cgo.go
@@ -621,11 +621,12 @@ func SetVertexAttributeDivisor(index uint32, divisor int32) {
 }
 
 // LoadTextureDepth - Load depth texture/renderbuffer (to be attached to fbo)
-func LoadTextureDepth(width, height int32, useRenderBuffer bool) {
+func LoadTextureDepth(width, height int32, useRenderBuffer bool) uint32 {
 	cwidth := C.int(width)
 	cheight := C.int(height)
 	cuseRenderBuffer := C.bool(useRenderBuffer)
-	C.rlLoadTextureDepth(cwidth, cheight, cuseRenderBuffer)
+	cid := C.rlLoadTextureDepth(cwidth, cheight, cuseRenderBuffer)
+	return uint32(cid)
 }
 
 // LoadFramebuffer - Load an empty framebuffer

--- a/raylib/rlgl_purego.go
+++ b/raylib/rlgl_purego.go
@@ -764,8 +764,8 @@ func SetVertexAttributeDivisor(index uint32, divisor int32) {
 }
 
 // LoadTextureDepth - Load depth texture/renderbuffer (to be attached to fbo)
-func LoadTextureDepth(width, height int32, useRenderBuffer bool) {
-	rlLoadTextureDepth(width, height, useRenderBuffer)
+func LoadTextureDepth(width, height int32, useRenderBuffer bool) uint32{
+	return rlLoadTextureDepth(width, height, useRenderBuffer)
 }
 
 // LoadFramebuffer - Load an empty framebuffer


### PR DESCRIPTION
Modified the `LoadTextureDepth` function in the Go bindings to return the texture depth ID (uint32). Previously, the function did not return anything, which made it difficult to access the texture ID directly in Go.
