### PR TITLE
add stub for GetClipboardImage() when building with drm tag

### DIFF
--- a/raylib/rcore.go
+++ b/raylib/rcore.go
@@ -3,6 +3,16 @@ package rl
 /*
 #include "raylib.h"
 #include <stdlib.h>
+
+#if !defined(SUPPORT_CLIPBOARD_IMAGE)
+// Get clipboard image stub - returns empty image
+Image GetClipboardImage(void)
+{
+    Image image = {0};
+    return image;
+}
+#endif
+
 */
 import "C"
 


### PR DESCRIPTION
The PR suggests to add the `GetClipboardImage()` stub to make the raylib-go code compilable with the "drm" tag. Without the change I got the linker error that the function `GetClipboardImage()` is not found.

Tested on Rapbery PI with the drm tag:

`go build -ldflags=$(LDFLAGS) -tags "drm noaudio" -o ${BUILD_DIR}/ ./cmd/...`