### PR TITLE
Add GetClipboardImage for drm platform.

### DIFF
--- a/raylib/platforms/rcore_drm.c
+++ b/raylib/platforms/rcore_drm.c
@@ -510,6 +510,16 @@ const char *GetClipboardText(void)
     return NULL;
 }
 
+// Get clipboard image
+Image GetClipboardImage(void)
+{
+    Image image = { 0 };
+
+    TRACELOG(LOG_WARNING, "GetClipboardImage() not implemented on target platform");
+
+    return image;
+}
+
 // Show mouse cursor
 void ShowCursor(void)
 {


### PR DESCRIPTION
The was a problem building the lib on raspberry pi with '-tags drm'