### PR TITLE
Change `WaveFormat` and `WaveCrop` signatures to accept a pointer to `Wave`

### DIFF
--- a/raylib/raudio.go
+++ b/raylib/raudio.go
@@ -299,7 +299,7 @@ func SetSoundPan(sound Sound, pan float32) {
 }
 
 // WaveFormat - Convert wave data to desired format
-func WaveFormat(wave Wave, sampleRate int32, sampleSize int32, channels int32) {
+func WaveFormat(wave *Wave, sampleRate int32, sampleSize int32, channels int32) {
 	cwave := wave.cptr()
 	csampleRate := (C.int)(sampleRate)
 	csampleSize := (C.int)(sampleSize)
@@ -316,7 +316,7 @@ func WaveCopy(wave Wave) Wave {
 }
 
 // WaveCrop - Crop a wave to defined frames range
-func WaveCrop(wave Wave, initFrame int32, finalFrame int32) {
+func WaveCrop(wave *Wave, initFrame int32, finalFrame int32) {
 	cwave := wave.cptr()
 	cinitFrame := (C.int)(initFrame)
 	cfinalFrame := (C.int)(finalFrame)


### PR DESCRIPTION
The raylib functions `WaveFormat` and `WaveCrop` accept a pointer to `Wave` because the wave is updated in-place. However, the current Go bindings pass a copy of the wave to the C functions, so it is not updated. This commit changes the signatures of the Go API so they also accept a pointer to `Wave`.