### PR TITLE
Unite WASM bindings with the rest

### DIFF
--- a/raylib/raylib.go
+++ b/raylib/raylib.go
@@ -20,6 +20,10 @@ func init() {
 	runtime.LockOSThread()
 }
 
+// For compatibility with WASM bindings.
+// https://github.com/BrownNPC/Raylib-Go-Wasm
+var SetMain = SetCallbackFunc
+
 // Wave type, defines audio wave data
 type Wave struct {
 	// Number of samples


### PR DESCRIPTION
I've begun implementing some of the things you mentioned on [the reddit post](https://www.reddit.com/r/raylib/comments/1l75oz8/comment/mwuyxhw/).

This PR just adds an alias `SetMain` for `rl.SetCallbackFunc `