### PR TITLE
Fix: lock mouse cursor in 3D maze example for correct camera control

### DIFF
--- a/examples/models/first_person_maze/main.go
+++ b/examples/models/first_person_maze/main.go
@@ -47,6 +47,8 @@ func main() {
 	mapPosition := rl.NewVector3(-16.0, 0.0, -8.0) // Set model position
 
 	rl.SetTargetFPS(60) // Set our game to run at 60 frames-per-second
+
+	rl.DisableCursor() // Locking the cursor to enable camera control with mouse
 	//--------------------------------------------------------------------------------------
 
 	// Main game loop


### PR DESCRIPTION
change : 
Added mouse navigation on 3D first_person_maze in the examples (examples/models/first_person_maze)