### PR TITLE
Fix rl.LoadWaveSamples returning only half of the samples

### DIFF
--- a/raylib/raudio.go
+++ b/raylib/raudio.go
@@ -333,7 +333,7 @@ func WaveCrop(wave *Wave, initFrame int32, finalFrame int32) {
 func LoadWaveSamples(wave Wave) []float32 {
 	cwave := wave.cptr()
 	ret := C.LoadWaveSamples(*cwave)
-	v := unsafe.Slice((*float32)(unsafe.Pointer(ret)), wave.FrameCount)
+	v := unsafe.Slice((*float32)(unsafe.Pointer(ret)), wave.FrameCount*wave.Channels)
 	return v
 }
 


### PR DESCRIPTION
The returned sample count was halved because the function used the frame count instead of the total sample count (frames * channels).