### PR TITLE
github-issue-524-windows-zig-compilation-dllexport

### DIFF
--- a/raylib/raudio.go
+++ b/raylib/raudio.go
@@ -7,7 +7,10 @@ package rl
 #include "raylib.h"
 #include <stdlib.h>
 
-__declspec(dllexport) extern void internalAudioStreamCallbackGo(void *, int);
+#if defined(_WIN32) || defined(WIN32) || defined(__WIN32__) || defined(__NT__)
+    __declspec(dllexport)
+#endif
+extern void internalAudioStreamCallbackGo(void *, int);
 
 static void audioStreamWrapperCallback(void *data, unsigned int frames) {
 	internalAudioStreamCallbackGo(data, frames);
@@ -17,7 +20,10 @@ static void setAudioStreamCallbackWrapper(AudioStream stream) {
 	SetAudioStreamCallback(stream, audioStreamWrapperCallback);
 }
 
-__declspec(dllexport) extern void internalAudioMixedProcessorGo(void *, int);
+#if defined(_WIN32) || defined(WIN32) || defined(__WIN32__) || defined(__NT__)
+    __declspec(dllexport)
+#endif
+extern void internalAudioMixedProcessorGo(void *, int);
 
 static void audioMixedProcessorCallback(void *data, unsigned int frames) {
 	internalAudioMixedProcessorGo(data, frames);


### PR DESCRIPTION
Issue: https://github.com/gen2brain/raylib-go/issues/524

- added __declspec(dllexport) to two raudio.go CGO externs to allow compatibility with zig as a C compiler for CGO with windows as the target