### PR TITLE
Fix CircOut easing to match C implementation

### DIFF
--- a/easings/easings.go
+++ b/easings/easings.go
@@ -65,7 +65,8 @@ func CircIn(t, b, c, d float32) float32 {
 // CircOut easing
 // t: current time, b: begInnIng value, c: change In value, d: duration
 func CircOut(t, b, c, d float32) float32 {
-	return c*float32(math.Sqrt(1-float64((t/d-1)*t))) + b
+	t = t/d - 1
+	return c*float32(math.Sqrt(1-float64(t*t))) + b
 }
 
 // CircInOut easing


### PR DESCRIPTION
The previous implementation incorrectly calculated (t/d-1)*t instead of squaring (t/d-1). 
This fix properly implements the circular easing formula to match the C version:
https://github.com/raysan5/raylib/blob/master/examples/shapes/reasings.h#L116