### PR TITLE
Add rlgl vertex draw bindings

### DIFF
--- a/examples/others/rlgl_instanced_quads/main.go
+++ b/examples/others/rlgl_instanced_quads/main.go
@@ -1,0 +1,244 @@
+// This example demonstrates instanced drawing with low-level rlgl bindings:
+//   - LoadVertexBufferElements: upload index data (EBO) to GPU
+//   - DrawVertexArrayElementsInstanced: instanced indexed draw
+//   - SetVertexAttributeDivisor: per-instance attribute advancement
+//   - Camera3D with BeginMode3D/EndMode3D for orbital 3D camera control
+//
+// 625 quads are rendered in a 25x25 grid with animated Y-offsets (sine wave).
+package main
+
+import (
+	"math"
+
+	rl "github.com/gen2brain/raylib-go/raylib"
+)
+
+const (
+	screenWidth  = 1024
+	screenHeight = 768
+
+	cols          = 25
+	rows          = 25
+	instanceCount = cols * rows
+	spacing       = 1.5
+)
+
+// GLSL 330 vertex shader with instancing support.
+const vertexShaderCode = `#version 330
+layout(location = 0) in vec3 vertexPosition;
+layout(location = 1) in vec2 vertexTexCoord;
+layout(location = 2) in vec3 instanceOffset;
+layout(location = 3) in vec4 instanceColor;
+
+uniform mat4 mvp;
+
+out vec4 fragColor;
+
+void main() {
+    gl_Position = mvp * vec4(vertexPosition + instanceOffset, 1.0);
+    fragColor = instanceColor;
+}
+`
+
+// GLSL 330 fragment shader.
+const fragmentShaderCode = `#version 330
+in vec4 fragColor;
+out vec4 finalColor;
+
+void main() {
+    finalColor = fragColor;
+}
+`
+
+func main() {
+	rl.SetConfigFlags(rl.FlagWindowResizable | rl.FlagMsaa4xHint)
+	rl.InitWindow(screenWidth, screenHeight, "rlgl instanced quads example")
+	defer rl.CloseWindow()
+	rl.SetTargetFPS(60)
+
+	// -----------------------------------------------------------------
+	// Quad geometry (XZ plane, unit-sized)
+	// -----------------------------------------------------------------
+	type QuadVertex struct {
+		Pos rl.Vector3
+		Tex rl.Vector2
+	}
+	// Texcords are implicitly zero, because we use the default white texture.
+	quadVertices := []QuadVertex{
+		{Pos: rl.NewVector3(-0.5, 0, -0.5)}, // 0 top-left
+		{Pos: rl.NewVector3(0.5, 0, -0.5)},  // 1 top-right
+		{Pos: rl.NewVector3(-0.5, 0, 0.5)},  // 2 bottom-left
+		{Pos: rl.NewVector3(0.5, 0, 0.5)},   // 3 bottom-right
+	}
+	quadIndices := []uint16{
+		0, 2, 1, // first triangle (CCW from above)
+		1, 2, 3, // second triangle
+	}
+
+	// -----------------------------------------------------------------
+	// Instance data: offsets and colors for 625 instances
+	// -----------------------------------------------------------------
+	instanceOffsets := make([]rl.Vector3, instanceCount)
+	instanceColors := make([]rl.Vector4, instanceCount)
+
+	// Center the grid at the origin
+	originX := -float32(cols-1) * spacing / 2.0
+	originZ := -float32(rows-1) * spacing / 2.0
+
+	for row := range rows {
+		for col := range cols {
+			i := row*cols + col
+			x := originX + float32(col)*spacing
+			z := originZ + float32(row)*spacing
+			instanceOffsets[i] = rl.NewVector3(x, 0, z)
+
+			// HSV gradient: hue from column, saturation from row
+			hue := float32(col) / float32(cols)
+			sat := 0.5 + 0.5*float32(row)/float32(rows-1)
+			r, g, b := hsvToRGB(hue, sat, 1.0)
+			instanceColors[i] = rl.NewVector4(r, g, b, 1.0)
+		}
+	}
+
+	// Working buffer for animated offsets
+	animOffsets := make([]rl.Vector3, instanceCount)
+
+	// -----------------------------------------------------------------
+	// VAO + VBO + EBO setup
+	// DONT FORGOT TO CLEANUP YOUR GPU RESOURCES
+	// -----------------------------------------------------------------
+	vao := rl.LoadVertexArray()
+	rl.EnableVertexArray(vao)
+
+	// Quad vertex VBO (static)
+	quadVBO := rl.LoadVertexBuffer(quadVertices, false)
+	defer rl.UnloadVertexBuffer(quadVBO)
+	rl.SetVertexAttributes(quadVertices, []rl.VertexAttributesConfig{
+		{Field: "Pos", Attribute: 0},
+		{Field: "Tex", Attribute: 1},
+	})
+
+	// Instance offset VBO (dynamic, updated each frame)
+	offsetVBO := rl.LoadVertexBuffer(animOffsets, true)
+	defer rl.UnloadVertexBuffer(offsetVBO)
+	rl.SetVertexAttribute(2, 3, rl.Float, false, 0, 0)
+	rl.EnableVertexAttribute(2)
+	rl.SetVertexAttributeDivisor(2, 1)
+
+	// Instance color VBO (static)
+	colorVBO := rl.LoadVertexBuffer(instanceColors, false)
+	defer rl.UnloadVertexBuffer(colorVBO)
+	rl.SetVertexAttribute(3, 4, rl.Float, false, 0, 0)
+	rl.EnableVertexAttribute(3)
+	rl.SetVertexAttributeDivisor(3, 1)
+
+	// Index buffer (EBO)
+	ebo := rl.LoadVertexBufferElements(quadIndices, false)
+	defer rl.UnloadVertexBuffer(ebo)
+
+	rl.DisableVertexArray()
+
+	// -----------------------------------------------------------------
+	// Custom shader
+	// -----------------------------------------------------------------
+	shaderID := rl.LoadShaderCode(vertexShaderCode, fragmentShaderCode)
+	defer rl.UnloadShaderProgram(shaderID)
+	mvpLoc := rl.GetLocationUniform(shaderID, "mvp")
+
+	// -----------------------------------------------------------------
+	// Camera
+	// -----------------------------------------------------------------
+	camera := rl.Camera3D{
+		Position:   rl.NewVector3(30, 25, 30),
+		Target:     rl.NewVector3(0, 0, 0),
+		Up:         rl.NewVector3(0, 1, 0),
+		Fovy:       45.0,
+		Projection: rl.CameraPerspective,
+	}
+
+	// -----------------------------------------------------------------
+	// Render loop
+	// -----------------------------------------------------------------
+	for !rl.WindowShouldClose() {
+		rl.UpdateCamera(&camera, rl.CameraOrbital)
+
+		// Animate instance Y-offsets with sine wave
+		t := float64(rl.GetTime())
+		for i := range instanceCount {
+			base := instanceOffsets[i]
+			// Phase based on XZ distance from origin for radial wave
+			phase := float64(base.X+base.Z) * 0.3
+			y := float32(math.Sin(t*2.0+phase)) * 2.0
+			animOffsets[i] = rl.NewVector3(base.X, y, base.Z)
+		}
+		rl.UpdateVertexBuffer(offsetVBO, animOffsets, 0)
+
+		rl.BeginDrawing()
+		rl.ClearBackground(rl.RayWhite)
+
+		rl.BeginMode3D(camera)
+
+		// Reference grid
+		rl.DrawGrid(40, 1.0)
+
+		// Build MVP from current camera matrices
+		mvp := rl.MatrixMultiply(rl.GetMatrixModelview(), rl.GetMatrixProjection())
+
+		// Flush raylib's internal batch before custom GL draws
+		rl.DrawRenderBatchActive()
+
+		// Custom instanced draw
+		rl.EnableShader(shaderID)
+		rl.SetUniformMatrix(mvpLoc, mvp)
+
+		rl.EnableVertexArray(vao)
+		rl.DrawVertexArrayElementsInstanced(0, 6, nil, int32(instanceCount))
+		rl.DisableVertexArray()
+
+		rl.DisableShader()
+
+		// Restore state for raylib's internal renderer
+		rl.DrawRenderBatchActive()
+
+		rl.EndMode3D()
+
+		// Text overlays
+		rl.DrawText("rlgl Instanced Quads (625 instances)", 10, 10, 20, rl.DarkGray)
+		rl.DrawText("Scroll to zoom", 10, 35, 16, rl.Gray)
+		rl.DrawFPS(int32(rl.GetScreenWidth())-100, 10)
+
+		rl.EndDrawing()
+	}
+}
+
+// hsvToRGB converts HSV (all 0-1 range) to RGB (0-1 range).
+func hsvToRGB(h, s, v float32) (r, g, b float32) {
+	if s == 0 {
+		return v, v, v
+	}
+	h *= 6.0
+	if h >= 6.0 {
+		h = 0
+	}
+	i := int(h)
+	f := h - float32(i)
+	p := v * (1.0 - s)
+	q := v * (1.0 - s*f)
+	t := v * (1.0 - s*(1.0-f))
+
+	switch i {
+	case 0:
+		r, g, b = v, t, p
+	case 1:
+		r, g, b = q, v, p
+	case 2:
+		r, g, b = p, v, t
+	case 3:
+		r, g, b = p, q, v
+	case 4:
+		r, g, b = t, p, v
+	default:
+		r, g, b = v, p, q
+	}
+	return
+}

--- a/examples/others/rlgl_vertex_buffer/main.go
+++ b/examples/others/rlgl_vertex_buffer/main.go
@@ -152,7 +152,7 @@ func main() {
 
 	// Orthographic projection: screen-space coordinates, origin top-left
 	// NOTE: rl.GetCameraMatrix2D/rl.GetCameraMatrix could be used to work with rl camera
-	// Need to test...
+  // See examples/others/rlgl_instanced_quad/main.go
 	mvpMatrix := rl.MatrixOrtho(0, screenWidth, screenHeight, 0, -1, 1)
 
 	// White diffuse color so vertex colors pass through unmodified

--- a/examples/others/rlgl_vertex_buffer/main.go
+++ b/examples/others/rlgl_vertex_buffer/main.go
@@ -10,7 +10,6 @@ package main
 import (
 	"fmt"
 	"math"
-	"unsafe"
 
 	rl "github.com/gen2brain/raylib-go/raylib"
 )
@@ -70,25 +69,25 @@ func main() {
 	rl.EnableVertexArray(quadVAO)
 
 	// Position VBO (attribute 0, vec3)
-	quadPosVBO := rl.LoadVertexBuffer(unsafe.Pointer(&quadPositions[0]), int32(len(quadPositions)*4), false)
+	quadPosVBO := rl.LoadVertexBuffer(quadPositions, false)
 	defer rl.UnloadVertexBuffer(quadPosVBO)
 	rl.SetVertexAttribute(0, 3, rl.Float, false, 0, 0)
 	rl.EnableVertexAttribute(0)
 
 	// Texcoord VBO (attribute 1, vec2)
-	quadTexVBO := rl.LoadVertexBuffer(unsafe.Pointer(&quadTexcoords[0]), int32(len(quadTexcoords)*4), false)
+	quadTexVBO := rl.LoadVertexBuffer(quadTexcoords, false)
 	defer rl.UnloadVertexBuffer(quadTexVBO)
 	rl.SetVertexAttribute(1, 2, rl.Float, false, 0, 0)
 	rl.EnableVertexAttribute(1)
 
 	// Color VBO (attribute 3, vec4) - dynamic for animation
-	quadColVBO := rl.LoadVertexBuffer(unsafe.Pointer(&quadColors[0]), int32(len(quadColors)*4), true)
+	quadColVBO := rl.LoadVertexBuffer(quadColors, true)
 	defer rl.UnloadVertexBuffer(quadColVBO)
 	rl.SetVertexAttribute(3, 4, rl.Float, false, 0, 0)
 	rl.EnableVertexAttribute(3)
 
 	// Index buffer (EBO)
-	quadIBO := rl.LoadVertexBufferElement(unsafe.Pointer(&quadIndices[0]), int32(len(quadIndices)*2), false)
+	quadIBO := rl.LoadVertexBufferElements(quadIndices, false)
 	defer rl.UnloadVertexBuffer(quadIBO)
 
 	rl.DisableVertexArray()
@@ -127,19 +126,19 @@ func main() {
 	rl.EnableVertexArray(triVAO)
 
 	// Position VBO (attribute 0, vec3)
-	triPosVBO := rl.LoadVertexBuffer(unsafe.Pointer(&triPositions[0]), int32(len(triPositions)*4), false)
+	triPosVBO := rl.LoadVertexBuffer(triPositions, false)
 	defer rl.UnloadVertexBuffer(triPosVBO)
 	rl.SetVertexAttribute(0, 3, rl.Float, false, 0, 0)
 	rl.EnableVertexAttribute(0)
 
 	// Texcoord VBO (attribute 1, vec2)
-	triTexVBO := rl.LoadVertexBuffer(unsafe.Pointer(&triTexcoords[0]), int32(len(triTexcoords)*4), false)
+	triTexVBO := rl.LoadVertexBuffer(triTexcoords, false)
 	defer rl.UnloadVertexBuffer(triTexVBO)
 	rl.SetVertexAttribute(1, 2, rl.Float, false, 0, 0)
 	rl.EnableVertexAttribute(1)
 
 	// Color VBO (attribute 3, vec4)
-	triColVBO := rl.LoadVertexBuffer(unsafe.Pointer(&triColors[0]), int32(len(triColors)*4), false)
+	triColVBO := rl.LoadVertexBuffer(triColors, false)
 	defer rl.UnloadVertexBuffer(triColVBO)
 	rl.SetVertexAttribute(3, 4, rl.Float, false, 0, 0)
 	rl.EnableVertexAttribute(3)
@@ -191,7 +190,7 @@ func main() {
 			animColors[i*4+2] = b
 			animColors[i*4+3] = 1.0
 		}
-		rl.UpdateVertexBuffer(quadColVBO, unsafe.Pointer(&animColors[0]), int32(len(animColors)*4), 0)
+		rl.UpdateVertexBuffer(quadColVBO, animColors, 0)
 
 		// Flush raylib's internal batch before custom GL draws
 		rl.DrawRenderBatchActive()

--- a/examples/others/rlgl_vertex_buffer/main.go
+++ b/examples/others/rlgl_vertex_buffer/main.go
@@ -151,7 +151,7 @@ func main() {
 		quadVAO, quadVBO, triangleVAO, triangleVBO)
 
 	// Orthographic projection: screen-space coordinates, origin top-left
-	// NOTE: rl.GetCameraMatrix2D/rl.GetCameraMatrix could be used to work with rl camera
+	// NOTE: rl.MatrixMultiply(rl.GetMatrixModelview(), rl.GetMatrixProjection()) could be used to work with rl camera
   // See examples/others/rlgl_instanced_quad/main.go
 	mvpMatrix := rl.MatrixOrtho(0, screenWidth, screenHeight, 0, -1, 1)
 

--- a/examples/others/rlgl_vertex_buffer/main.go
+++ b/examples/others/rlgl_vertex_buffer/main.go
@@ -1,0 +1,229 @@
+// This example demonstrates the low-level rlgl vertex buffer bindings:
+//   - LoadVertexBuffer / LoadVertexBufferElement: upload vertex + index data to GPU
+//   - SetVertexAttribute: configure vertex attribute pointers
+//   - SetVertexAttributeDefault: provide default values for unused attributes
+//   - DrawVertexArrayElements: indexed draw (quad)
+//   - DrawVertexArray: non-indexed draw (triangle)
+//   - UpdateVertexBuffer: animate vertex colors each frame
+package main
+
+import (
+	"fmt"
+	"math"
+	"unsafe"
+
+	rl "github.com/gen2brain/raylib-go/raylib"
+)
+
+const (
+	screenWidth  = 800
+	screenHeight = 600
+)
+
+func main() {
+	rl.InitWindow(screenWidth, screenHeight, "rlgl vertex buffer example")
+	defer rl.CloseWindow()
+	rl.SetTargetFPS(60)
+
+	// ---------------------------------------------------------------
+	// Quad (indexed draw) - centered on left half of screen
+	// Vertices ordered CCW in NDC (since ortho flips Y, screen-CW = NDC-CW,
+	// so we use CCW winding via index order)
+	// ---------------------------------------------------------------
+	quadPositions := []float32{
+		// x, y,  z
+		150, 150, 0, // 0: top-left
+		450, 150, 0, // 1: top-right
+		450, 450, 0, // 2: bottom-right
+		150, 450, 0, // 3: bottom-left
+	}
+
+	quadColors := []float32{
+		// r, g, b, a  (one color per corner)
+		1, 0, 0, 1, // red
+		0, 1, 0, 1, // green
+		0, 0, 1, 1, // blue
+		1, 1, 0, 1, // yellow
+	}
+
+	// Texcoords (all zeros - we only need the default white texture)
+	quadTexcoords := []float32{
+		0, 0,
+		0, 0,
+		0, 0,
+		0, 0,
+	}
+
+	// CCW winding in NDC (with Y-flip ortho: reverse the original CW order)
+	quadIndices := []uint16{
+		0, 2, 1, // first triangle (CCW in NDC)
+		0, 3, 2, // second triangle (CCW in NDC)
+	}
+
+	// ---------------------------------------------------------------
+	// Quad VAO, VBO, and EBO Creations
+	// DONT FORGOT TO CLEANUP YOUR GPU RESOURCES
+	// ---------------------------------------------------------------
+
+	// Create quad VAO
+	quadVAO := rl.LoadVertexArray()
+	rl.EnableVertexArray(quadVAO)
+
+	// Position VBO (attribute 0, vec3)
+	quadPosVBO := rl.LoadVertexBuffer(unsafe.Pointer(&quadPositions[0]), int32(len(quadPositions)*4), false)
+	defer rl.UnloadVertexBuffer(quadPosVBO)
+	rl.SetVertexAttribute(0, 3, rl.Float, false, 0, 0)
+	rl.EnableVertexAttribute(0)
+
+	// Texcoord VBO (attribute 1, vec2)
+	quadTexVBO := rl.LoadVertexBuffer(unsafe.Pointer(&quadTexcoords[0]), int32(len(quadTexcoords)*4), false)
+	defer rl.UnloadVertexBuffer(quadTexVBO)
+	rl.SetVertexAttribute(1, 2, rl.Float, false, 0, 0)
+	rl.EnableVertexAttribute(1)
+
+	// Color VBO (attribute 3, vec4) - dynamic for animation
+	quadColVBO := rl.LoadVertexBuffer(unsafe.Pointer(&quadColors[0]), int32(len(quadColors)*4), true)
+	defer rl.UnloadVertexBuffer(quadColVBO)
+	rl.SetVertexAttribute(3, 4, rl.Float, false, 0, 0)
+	rl.EnableVertexAttribute(3)
+
+	// Index buffer (EBO)
+	quadIBO := rl.LoadVertexBufferElement(unsafe.Pointer(&quadIndices[0]), int32(len(quadIndices)*2), false)
+	defer rl.UnloadVertexBuffer(quadIBO)
+
+	rl.DisableVertexArray()
+
+	// ---------------------------------------------------------------
+	// Triangle (non-indexed draw) - on the right side
+	// Vertices in CCW order in NDC (with Y-flip ortho)
+	// ---------------------------------------------------------------
+	triPositions := []float32{
+		// x, y, z  (CCW in NDC with Y-flip)
+		575, 200, 0, // top
+		575, 450, 0, // bottom-left
+		700, 450, 0, // bottom-right
+	}
+
+	triColors := []float32{
+		// r, g, b, a
+		1.0, 0.0, 1.0, 1.0, // magenta
+		0.0, 1.0, 1.0, 1.0, // cyan
+		1.0, 1.0, 1.0, 1.0, // white
+	}
+
+	triTexcoords := []float32{
+		0, 0,
+		0, 0,
+		0, 0,
+	}
+
+	// ---------------------------------------------------------------
+  // Triangle VAO, and VBO creation
+	// DONT FORGOT TO CLEANUP YOUR GPU RESOURCES
+	// ---------------------------------------------------------------
+
+	// Create triangle VAO
+	triVAO := rl.LoadVertexArray()
+	rl.EnableVertexArray(triVAO)
+
+	// Position VBO (attribute 0, vec3)
+	triPosVBO := rl.LoadVertexBuffer(unsafe.Pointer(&triPositions[0]), int32(len(triPositions)*4), false)
+	defer rl.UnloadVertexBuffer(triPosVBO)
+	rl.SetVertexAttribute(0, 3, rl.Float, false, 0, 0)
+	rl.EnableVertexAttribute(0)
+
+	// Texcoord VBO (attribute 1, vec2)
+	triTexVBO := rl.LoadVertexBuffer(unsafe.Pointer(&triTexcoords[0]), int32(len(triTexcoords)*4), false)
+	defer rl.UnloadVertexBuffer(triTexVBO)
+	rl.SetVertexAttribute(1, 2, rl.Float, false, 0, 0)
+	rl.EnableVertexAttribute(1)
+
+	// Color VBO (attribute 3, vec4)
+	triColVBO := rl.LoadVertexBuffer(unsafe.Pointer(&triColors[0]), int32(len(triColors)*4), false)
+	defer rl.UnloadVertexBuffer(triColVBO)
+	rl.SetVertexAttribute(3, 4, rl.Float, false, 0, 0)
+	rl.EnableVertexAttribute(3)
+
+	rl.DisableVertexArray()
+
+	// ---------------------------------------------------------------
+	// Shader + MVP setup
+	// ---------------------------------------------------------------
+	defaultShaderID := rl.GetShaderIdDefault()
+	mvpLoc := rl.GetLocationUniform(defaultShaderID, "mvp")
+	colDiffuseLoc := rl.GetLocationUniform(defaultShaderID, "colDiffuse")
+	defaultTexID := rl.GetTextureIdDefault()
+
+	fmt.Printf("DEBUG: shaderID=%d mvpLoc=%d colDiffuseLoc=%d texID=%d\n",
+		defaultShaderID, mvpLoc, colDiffuseLoc, defaultTexID)
+	fmt.Printf("DEBUG: quadVAO=%d quadPosVBO=%d quadColVBO=%d quadIBO=%d\n",
+		quadVAO, quadPosVBO, quadColVBO, quadIBO)
+	fmt.Printf("DEBUG: triVAO=%d triPosVBO=%d triColVBO=%d\n",
+		triVAO, triPosVBO, triColVBO)
+
+	// Orthographic projection: screen-space coordinates, origin top-left
+  // NOTE: rl.GetCameraMatrix2D/rl.GetCameraMatrix could be used to work with rl camera
+  // Need to test...
+	mvpMatrix := rl.MatrixOrtho(0, screenWidth, screenHeight, 0, -1, 1)
+
+	// White diffuse color so vertex colors pass through unmodified
+	whiteDiffuse := []float32{1, 1, 1, 1}
+
+	// Working buffer for animated quad colors
+	animColors := make([]float32, len(quadColors))
+
+	for !rl.WindowShouldClose() {
+		rl.BeginDrawing()
+		rl.ClearBackground(rl.RayWhite)
+
+		// ---------------------------------------------------------------
+		// Animated quad colors
+		// Thanks Inigo: https://iquilezles.org/articles/palettes/
+		// ---------------------------------------------------------------
+		t := float32(rl.GetTime())
+		for i := range 4 {
+			phase := float32(i) * math.Pi / 2.0
+			r := 0.5 + 0.5*float32(math.Sin(float64(t*2.0+phase)))
+			g := 0.5 + 0.5*float32(math.Sin(float64(t*2.0+phase+math.Pi*2.0/3.0)))
+			b := 0.5 + 0.5*float32(math.Sin(float64(t*2.0+phase+math.Pi*4.0/3.0)))
+			animColors[i*4+0] = r
+			animColors[i*4+1] = g
+			animColors[i*4+2] = b
+			animColors[i*4+3] = 1.0
+		}
+		rl.UpdateVertexBuffer(quadColVBO, unsafe.Pointer(&animColors[0]), int32(len(animColors)*4), 0)
+
+		// Flush raylib's internal batch before custom GL draws
+		rl.DrawRenderBatchActive()
+
+		// Set up default shader for our custom VAO draws
+		rl.EnableShader(defaultShaderID)
+		rl.SetUniformMatrix(mvpLoc, mvpMatrix)
+		rl.SetUniform(colDiffuseLoc, whiteDiffuse, int32(rl.ShaderUniformVec4), 1)
+		rl.ActiveTextureSlot(0)
+		rl.EnableTexture(defaultTexID)
+
+		// Draw quad (indexed)
+		rl.EnableVertexArray(quadVAO)
+		rl.DrawVertexArrayElements(0, 6, nil)
+		rl.DisableVertexArray()
+
+		// Draw triangle (non-indexed)
+		rl.EnableVertexArray(triVAO)
+		rl.DrawVertexArray(0, 3)
+		rl.DisableVertexArray()
+
+		rl.CheckErrors()
+
+		// Restore state for raylib's internal renderer
+		rl.DisableShader()
+		rl.DisableTexture()
+		rl.DrawRenderBatchActive()
+
+		// Text overlays
+		rl.DrawText("rlgl Vertex Buffer Bindings Test", 10, 10, 20, rl.DarkGray)
+		rl.DrawFPS(int32(rl.GetScreenWidth())-100, 10)
+
+		rl.EndDrawing()
+	}
+}

--- a/raylib/rlgl.go
+++ b/raylib/rlgl.go
@@ -32,8 +32,15 @@ const (
 	Quads     = 0x0007 // GL_QUADS
 
 	// GL equivalent data types
-	UnsignedByte = 0x1401 // GL_UNSIGNED_BYTE
-	Float        = 0x1406 // GL_FLOAT
+	Byte          = 0x1400 // GL_BYTE
+	UnsignedByte  = 0x1401 // GL_UNSIGNED_BYTE
+	Short         = 0x1402 // GL_SHORT
+	UnsignedShort = 0x1403 // GL_UNSIGNED_SHORT
+	Int           = 0x1404 // GL_INT
+	UnsignedInt   = 0x1405 // GL_UNSIGNED_INT
+	Float         = 0x1406 // GL_FLOAT
+	Double        = 0x140A // GL_DOUBLE
+	HalfFloat     = 0x140B // GL_HALF_FLOAT
 
 	// Buffer usage hint
 	StreamDraw  = 0x88E0 // GL_STREAM_DRAW

--- a/raylib/rlgl_cgo.go
+++ b/raylib/rlgl_cgo.go
@@ -621,35 +621,51 @@ func SetVertexAttributeDivisor(index uint32, divisor int32) {
 }
 
 // LoadVertexBuffer - Load a vertex buffer object
-func LoadVertexBuffer(buffer unsafe.Pointer, size int32, dynamic bool) uint32 {
-	cbuffer := buffer
-	csize := C.int(size)
+func LoadVertexBuffer[T any](buffer []T, dynamic bool) uint32 {
+	if len(buffer) == 0 {
+		return 0
+	}
+	var z T
+	cbuffer := unsafe.Pointer(&buffer[0])
+	csize := C.int(int(unsafe.Sizeof(z)) * len(buffer))
 	cdynamic := C.bool(dynamic)
 	return uint32(C.rlLoadVertexBuffer(cbuffer, csize, cdynamic))
 }
 
-// LoadVertexBufferElement - Load vertex buffer elements object
-func LoadVertexBufferElement(buffer unsafe.Pointer, size int32, dynamic bool) uint32 {
-	cbuffer := buffer
-	csize := C.int(size)
+// LoadVertexBufferElements - Load vertex buffer elements object
+func LoadVertexBufferElements[T any](buffer []T, dynamic bool) uint32 {
+	if len(buffer) == 0 {
+		return 0
+	}
+	var z T
+	cbuffer := unsafe.Pointer(&buffer[0])
+	csize := C.int(int(unsafe.Sizeof(z)) * len(buffer))
 	cdynamic := C.bool(dynamic)
 	return uint32(C.rlLoadVertexBufferElement(cbuffer, csize, cdynamic))
 }
 
 // UpdateVertexBuffer - Update vertex buffer object data on GPU buffer
-func UpdateVertexBuffer(bufferId uint32, data unsafe.Pointer, dataSize int32, offset int32) {
+func UpdateVertexBuffer[T any](bufferId uint32, data []T, offset int32) {
+	if len(data) == 0 {
+		return
+	}
+	var z T
 	cbufferId := C.uint(bufferId)
-	cdata := data
-	cdataSize := C.int(dataSize)
+	cdata := unsafe.Pointer(&data[0])
+	cdataSize := C.int(int(unsafe.Sizeof(z)) * len(data))
 	coffset := C.int(offset)
 	C.rlUpdateVertexBuffer(cbufferId, cdata, cdataSize, coffset)
 }
 
 // UpdateVertexBufferElements - Update vertex buffer elements data on GPU buffer
-func UpdateVertexBufferElements(id uint32, data unsafe.Pointer, dataSize int32, offset int32) {
+func UpdateVertexBufferElements[T any](id uint32, data []T, offset int32) {
+	if len(data) == 0 {
+		return
+	}
+	var z T
 	cid := C.uint(id)
-	cdata := data
-	cdataSize := C.int(dataSize)
+	cdata := unsafe.Pointer(&data[0])
+	cdataSize := C.int(int(unsafe.Sizeof(z)) * len(data))
 	coffset := C.int(offset)
 	C.rlUpdateVertexBufferElements(cid, cdata, cdataSize, coffset)
 }

--- a/raylib/rlgl_cgo.go
+++ b/raylib/rlgl_cgo.go
@@ -625,7 +625,6 @@ func LoadVertexBuffer[T any](buffer []T, dynamic bool) uint32 {
 	if len(buffer) == 0 {
 		return 0
 	}
-	var z T
 	cbuffer := unsafe.Pointer(&buffer[0])
 	csize := C.int(int(unsafe.Sizeof(buffer[0])) * len(buffer))
 	cdynamic := C.bool(dynamic)
@@ -637,7 +636,6 @@ func LoadVertexBufferElements[T any](buffer []T, dynamic bool) uint32 {
 	if len(buffer) == 0 {
 		return 0
 	}
-	var z T
 	cbuffer := unsafe.Pointer(&buffer[0])
 	csize := C.int(int(unsafe.Sizeof(buffer[0])) * len(buffer))
 	cdynamic := C.bool(dynamic)
@@ -649,7 +647,6 @@ func UpdateVertexBuffer[T any](bufferId uint32, data []T, offset int32) {
 	if len(data) == 0 {
 		return
 	}
-	var z T
 	cbufferId := C.uint(bufferId)
 	cdata := unsafe.Pointer(&data[0])
 	cdataSize := C.int(int(unsafe.Sizeof(data[0])) * len(data))
@@ -662,7 +659,6 @@ func UpdateVertexBufferElements[T any](id uint32, data []T, offset int32) {
 	if len(data) == 0 {
 		return
 	}
-	var z T
 	cid := C.uint(id)
 	cdata := unsafe.Pointer(&data[0])
 	cdataSize := C.int(int(unsafe.Sizeof(data[0])) * len(data))

--- a/raylib/rlgl_cgo.go
+++ b/raylib/rlgl_cgo.go
@@ -620,6 +620,92 @@ func SetVertexAttributeDivisor(index uint32, divisor int32) {
 	C.rlSetVertexAttributeDivisor(cindex, cdivisor)
 }
 
+// LoadVertexBuffer - Load a vertex buffer object
+func LoadVertexBuffer(buffer unsafe.Pointer, size int32, dynamic bool) uint32 {
+	cbuffer := buffer
+	csize := C.int(size)
+	cdynamic := C.bool(dynamic)
+	return uint32(C.rlLoadVertexBuffer(cbuffer, csize, cdynamic))
+}
+
+// LoadVertexBufferElement - Load vertex buffer elements object
+func LoadVertexBufferElement(buffer unsafe.Pointer, size int32, dynamic bool) uint32 {
+	cbuffer := buffer
+	csize := C.int(size)
+	cdynamic := C.bool(dynamic)
+	return uint32(C.rlLoadVertexBufferElement(cbuffer, csize, cdynamic))
+}
+
+// UpdateVertexBuffer - Update vertex buffer object data on GPU buffer
+func UpdateVertexBuffer(bufferId uint32, data unsafe.Pointer, dataSize int32, offset int32) {
+	cbufferId := C.uint(bufferId)
+	cdata := data
+	cdataSize := C.int(dataSize)
+	coffset := C.int(offset)
+	C.rlUpdateVertexBuffer(cbufferId, cdata, cdataSize, coffset)
+}
+
+// UpdateVertexBufferElements - Update vertex buffer elements data on GPU buffer
+func UpdateVertexBufferElements(id uint32, data unsafe.Pointer, dataSize int32, offset int32) {
+	cid := C.uint(id)
+	cdata := data
+	cdataSize := C.int(dataSize)
+	coffset := C.int(offset)
+	C.rlUpdateVertexBufferElements(cid, cdata, cdataSize, coffset)
+}
+
+// SetVertexAttribute - Set vertex attribute data configuration
+func SetVertexAttribute(index uint32, compSize int32, attrType int32, normalized bool, stride int32, offset int32) {
+	cindex := C.uint(index)
+	ccompSize := C.int(compSize)
+	cattrType := C.int(attrType)
+	cnormalized := C.bool(normalized)
+	cstride := C.int(stride)
+	coffset := C.int(offset)
+	C.rlSetVertexAttribute(cindex, ccompSize, cattrType, cnormalized, cstride, coffset)
+}
+
+// SetVertexAttributeDefault - Set vertex attribute default value, when attribute to provided
+func SetVertexAttributeDefault(locIndex int32, value unsafe.Pointer, attribType int32, count int32) {
+	clocIndex := C.int(locIndex)
+	cvalue := value
+	cattribType := C.int(attribType)
+	ccount := C.int(count)
+	C.rlSetVertexAttributeDefault(clocIndex, cvalue, cattribType, ccount)
+}
+
+// DrawVertexArray - Draw vertex array (currently active vao)
+func DrawVertexArray(offset int32, count int32) {
+	coffset := C.int(offset)
+	ccount := C.int(count)
+	C.rlDrawVertexArray(coffset, ccount)
+}
+
+// DrawVertexArrayElements - Draw vertex array elements
+func DrawVertexArrayElements(offset int32, count int32, buffer unsafe.Pointer) {
+	coffset := C.int(offset)
+	ccount := C.int(count)
+	cbuffer := buffer
+	C.rlDrawVertexArrayElements(coffset, ccount, cbuffer)
+}
+
+// DrawVertexArrayInstanced - Draw vertex array (currently active vao) with instancing
+func DrawVertexArrayInstanced(offset int32, count int32, instances int32) {
+	coffset := C.int(offset)
+	ccount := C.int(count)
+	cinstances := C.int(instances)
+	C.rlDrawVertexArrayInstanced(coffset, ccount, cinstances)
+}
+
+// DrawVertexArrayElementsInstanced - Draw vertex array elements with instancing
+func DrawVertexArrayElementsInstanced(offset int32, count int32, buffer unsafe.Pointer, instances int32) {
+	coffset := C.int(offset)
+	ccount := C.int(count)
+	cbuffer := buffer
+	cinstances := C.int(instances)
+	C.rlDrawVertexArrayElementsInstanced(coffset, ccount, cbuffer, cinstances)
+}
+
 // LoadTextureDepth - Load depth texture/renderbuffer (to be attached to fbo)
 func LoadTextureDepth(width, height int32, useRenderBuffer bool) uint32 {
 	cwidth := C.int(width)

--- a/raylib/rlgl_cgo.go
+++ b/raylib/rlgl_cgo.go
@@ -627,7 +627,7 @@ func LoadVertexBuffer[T any](buffer []T, dynamic bool) uint32 {
 	}
 	var z T
 	cbuffer := unsafe.Pointer(&buffer[0])
-	csize := C.int(int(unsafe.Sizeof(z)) * len(buffer))
+	csize := C.int(int(unsafe.Sizeof(buffer[0])) * len(buffer))
 	cdynamic := C.bool(dynamic)
 	return uint32(C.rlLoadVertexBuffer(cbuffer, csize, cdynamic))
 }
@@ -639,7 +639,7 @@ func LoadVertexBufferElements[T any](buffer []T, dynamic bool) uint32 {
 	}
 	var z T
 	cbuffer := unsafe.Pointer(&buffer[0])
-	csize := C.int(int(unsafe.Sizeof(z)) * len(buffer))
+	csize := C.int(int(unsafe.Sizeof(buffer[0])) * len(buffer))
 	cdynamic := C.bool(dynamic)
 	return uint32(C.rlLoadVertexBufferElement(cbuffer, csize, cdynamic))
 }
@@ -652,7 +652,7 @@ func UpdateVertexBuffer[T any](bufferId uint32, data []T, offset int32) {
 	var z T
 	cbufferId := C.uint(bufferId)
 	cdata := unsafe.Pointer(&data[0])
-	cdataSize := C.int(int(unsafe.Sizeof(z)) * len(data))
+	cdataSize := C.int(int(unsafe.Sizeof(data[0])) * len(data))
 	coffset := C.int(offset)
 	C.rlUpdateVertexBuffer(cbufferId, cdata, cdataSize, coffset)
 }
@@ -665,7 +665,7 @@ func UpdateVertexBufferElements[T any](id uint32, data []T, offset int32) {
 	var z T
 	cid := C.uint(id)
 	cdata := unsafe.Pointer(&data[0])
-	cdataSize := C.int(int(unsafe.Sizeof(z)) * len(data))
+	cdataSize := C.int(int(unsafe.Sizeof(data[0])) * len(data))
 	coffset := C.int(offset)
 	C.rlUpdateVertexBufferElements(cid, cdata, cdataSize, coffset)
 }

--- a/raylib/rlgl_purego.go
+++ b/raylib/rlgl_purego.go
@@ -789,7 +789,7 @@ func LoadVertexBuffer[T any](buffer []T, dynamic bool) uint32 {
 		return 0
 	}
 	var z T
-	size := int32(int(unsafe.Sizeof(z)) * len(buffer))
+	size := int32(int(unsafe.Sizeof(buffer[0])) * len(buffer))
 	return rlLoadVertexBuffer(unsafe.Pointer(&buffer[0]), size, dynamic)
 }
 
@@ -799,7 +799,7 @@ func LoadVertexBufferElement[T any](buffer []T, dynamic bool) uint32 {
 		return 0
 	}
 	var z T
-	size := int32(int(unsafe.Sizeof(z)) * len(buffer))
+	size := int32(int(unsafe.Sizeof(buffer[0])) * len(buffer))
 	return rlLoadVertexBufferElement(unsafe.Pointer(&buffer[0]), size, dynamic)
 }
 
@@ -809,7 +809,7 @@ func UpdateVertexBuffer[T any](bufferId uint32, data []T, offset int32) {
 		return
 	}
 	var z T
-	dataSize := int32(int(unsafe.Sizeof(z)) * len(data))
+	dataSize := int32(int(unsafe.Sizeof(data[0])) * len(data))
 	rlUpdateVertexBuffer(bufferId, unsafe.Pointer(&data[0]), dataSize, offset)
 }
 

--- a/raylib/rlgl_purego.go
+++ b/raylib/rlgl_purego.go
@@ -784,23 +784,43 @@ func SetVertexAttributeDivisor(index uint32, divisor int32) {
 }
 
 // LoadVertexBuffer - Load a vertex buffer object
-func LoadVertexBuffer(buffer unsafe.Pointer, size int32, dynamic bool) uint32 {
-	return rlLoadVertexBuffer(buffer, size, dynamic)
+func LoadVertexBuffer[T any](buffer []T, dynamic bool) uint32 {
+	if len(buffer) == 0 {
+		return 0
+	}
+	var z T
+	size := int32(int(unsafe.Sizeof(z)) * len(buffer))
+	return rlLoadVertexBuffer(unsafe.Pointer(&buffer[0]), size, dynamic)
 }
 
 // LoadVertexBufferElement - Load vertex buffer elements object
-func LoadVertexBufferElement(buffer unsafe.Pointer, size int32, dynamic bool) uint32 {
-	return rlLoadVertexBufferElement(buffer, size, dynamic)
+func LoadVertexBufferElement[T any](buffer []T, dynamic bool) uint32 {
+	if len(buffer) == 0 {
+		return 0
+	}
+	var z T
+	size := int32(int(unsafe.Sizeof(z)) * len(buffer))
+	return rlLoadVertexBufferElement(unsafe.Pointer(&buffer[0]), size, dynamic)
 }
 
 // UpdateVertexBuffer - Update vertex buffer object data on GPU buffer
-func UpdateVertexBuffer(bufferId uint32, data unsafe.Pointer, dataSize int32, offset int32) {
-	rlUpdateVertexBuffer(bufferId, data, dataSize, offset)
+func UpdateVertexBuffer[T any](bufferId uint32, data []T, offset int32) {
+	if len(data) == 0 {
+		return
+	}
+	var z T
+	dataSize := int32(int(unsafe.Sizeof(z)) * len(data))
+	rlUpdateVertexBuffer(bufferId, unsafe.Pointer(&data[0]), dataSize, offset)
 }
 
 // UpdateVertexBufferElements - Update vertex buffer elements data on GPU buffer
-func UpdateVertexBufferElements(id uint32, data unsafe.Pointer, dataSize int32, offset int32) {
-	rlUpdateVertexBufferElements(id, data, dataSize, offset)
+func UpdateVertexBufferElements[T any](id uint32, data []T, offset int32) {
+	if len(data) == 0 {
+		return
+	}
+	var z T
+	dataSize := int32(int(unsafe.Sizeof(z)) * len(data))
+	rlUpdateVertexBufferElements(id, unsafe.Pointer(&data[0]), dataSize, offset)
 }
 
 // SetVertexAttribute - Set vertex attribute data configuration

--- a/raylib/rlgl_purego.go
+++ b/raylib/rlgl_purego.go
@@ -815,7 +815,7 @@ func UpdateVertexBufferElements[T any](id uint32, data []T, offset int32) {
 	if len(data) == 0 {
 		return
 	}
-	dataSize := int32(int(unsafe.Sizeof(z)) * len(data))
+	dataSize := int32(int(unsafe.Sizeof(data[0])) * len(data))
 	rlUpdateVertexBufferElements(id, unsafe.Pointer(&data[0]), dataSize, offset)
 }
 

--- a/raylib/rlgl_purego.go
+++ b/raylib/rlgl_purego.go
@@ -104,6 +104,16 @@ var rlSetTexture func(id uint32)
 var rlLoadVertexArray func() uint32
 var rlUnloadVertexBuffer func(vboId uint32)
 var rlSetVertexAttributeDivisor func(index uint32, divisor int32)
+var rlLoadVertexBuffer func(buffer unsafe.Pointer, size int32, dynamic bool) uint32
+var rlLoadVertexBufferElement func(buffer unsafe.Pointer, size int32, dynamic bool) uint32
+var rlUpdateVertexBuffer func(bufferId uint32, data unsafe.Pointer, dataSize int32, offset int32)
+var rlUpdateVertexBufferElements func(id uint32, data unsafe.Pointer, dataSize int32, offset int32)
+var rlSetVertexAttribute func(index uint32, compSize int32, attrType int32, normalized bool, stride int32, offset int32)
+var rlSetVertexAttributeDefault func(locIndex int32, value unsafe.Pointer, attribType int32, count int32)
+var rlDrawVertexArray func(offset int32, count int32)
+var rlDrawVertexArrayElements func(offset int32, count int32, buffer unsafe.Pointer)
+var rlDrawVertexArrayInstanced func(offset int32, count int32, instances int32)
+var rlDrawVertexArrayElementsInstanced func(offset int32, count int32, buffer unsafe.Pointer, instances int32)
 var rlLoadTextureDepth func(width int32, height int32, useRenderBuffer bool) uint32
 var rlLoadFramebuffer func() uint32
 var rlFramebufferAttach func(fboId uint32, texId uint32, attachType int32, texType int32, mipLevel int32)
@@ -237,6 +247,16 @@ func initRlglPurego() {
 	purego.RegisterLibFunc(&rlLoadVertexArray, raylibDll, "rlLoadVertexArray")
 	purego.RegisterLibFunc(&rlUnloadVertexBuffer, raylibDll, "rlUnloadVertexBuffer")
 	purego.RegisterLibFunc(&rlSetVertexAttributeDivisor, raylibDll, "rlSetVertexAttributeDivisor")
+	purego.RegisterLibFunc(&rlLoadVertexBuffer, raylibDll, "rlLoadVertexBuffer")
+	purego.RegisterLibFunc(&rlLoadVertexBufferElement, raylibDll, "rlLoadVertexBufferElement")
+	purego.RegisterLibFunc(&rlUpdateVertexBuffer, raylibDll, "rlUpdateVertexBuffer")
+	purego.RegisterLibFunc(&rlUpdateVertexBufferElements, raylibDll, "rlUpdateVertexBufferElements")
+	purego.RegisterLibFunc(&rlSetVertexAttribute, raylibDll, "rlSetVertexAttribute")
+	purego.RegisterLibFunc(&rlSetVertexAttributeDefault, raylibDll, "rlSetVertexAttributeDefault")
+	purego.RegisterLibFunc(&rlDrawVertexArray, raylibDll, "rlDrawVertexArray")
+	purego.RegisterLibFunc(&rlDrawVertexArrayElements, raylibDll, "rlDrawVertexArrayElements")
+	purego.RegisterLibFunc(&rlDrawVertexArrayInstanced, raylibDll, "rlDrawVertexArrayInstanced")
+	purego.RegisterLibFunc(&rlDrawVertexArrayElementsInstanced, raylibDll, "rlDrawVertexArrayElementsInstanced")
 	purego.RegisterLibFunc(&rlLoadTextureDepth, raylibDll, "rlLoadTextureDepth")
 	purego.RegisterLibFunc(&rlLoadFramebuffer, raylibDll, "rlLoadFramebuffer")
 	purego.RegisterLibFunc(&rlFramebufferAttach, raylibDll, "rlFramebufferAttach")
@@ -761,6 +781,56 @@ func UnloadVertexBuffer(vboId uint32) {
 // SetVertexAttributeDivisor .
 func SetVertexAttributeDivisor(index uint32, divisor int32) {
 	rlSetVertexAttributeDivisor(index, divisor)
+}
+
+// LoadVertexBuffer - Load a vertex buffer object
+func LoadVertexBuffer(buffer unsafe.Pointer, size int32, dynamic bool) uint32 {
+	return rlLoadVertexBuffer(buffer, size, dynamic)
+}
+
+// LoadVertexBufferElement - Load vertex buffer elements object
+func LoadVertexBufferElement(buffer unsafe.Pointer, size int32, dynamic bool) uint32 {
+	return rlLoadVertexBufferElement(buffer, size, dynamic)
+}
+
+// UpdateVertexBuffer - Update vertex buffer object data on GPU buffer
+func UpdateVertexBuffer(bufferId uint32, data unsafe.Pointer, dataSize int32, offset int32) {
+	rlUpdateVertexBuffer(bufferId, data, dataSize, offset)
+}
+
+// UpdateVertexBufferElements - Update vertex buffer elements data on GPU buffer
+func UpdateVertexBufferElements(id uint32, data unsafe.Pointer, dataSize int32, offset int32) {
+	rlUpdateVertexBufferElements(id, data, dataSize, offset)
+}
+
+// SetVertexAttribute - Set vertex attribute data configuration
+func SetVertexAttribute(index uint32, compSize int32, attrType int32, normalized bool, stride int32, offset int32) {
+	rlSetVertexAttribute(index, compSize, attrType, normalized, stride, offset)
+}
+
+// SetVertexAttributeDefault - Set vertex attribute default value
+func SetVertexAttributeDefault(locIndex int32, value unsafe.Pointer, attribType int32, count int32) {
+	rlSetVertexAttributeDefault(locIndex, value, attribType, count)
+}
+
+// DrawVertexArray - Draw vertex array (currently active vao)
+func DrawVertexArray(offset int32, count int32) {
+	rlDrawVertexArray(offset, count)
+}
+
+// DrawVertexArrayElements - Draw vertex array elements
+func DrawVertexArrayElements(offset int32, count int32, buffer unsafe.Pointer) {
+	rlDrawVertexArrayElements(offset, count, buffer)
+}
+
+// DrawVertexArrayInstanced - Draw vertex array (currently active vao) with instancing
+func DrawVertexArrayInstanced(offset int32, count int32, instances int32) {
+	rlDrawVertexArrayInstanced(offset, count, instances)
+}
+
+// DrawVertexArrayElementsInstanced - Draw vertex array elements with instancing
+func DrawVertexArrayElementsInstanced(offset int32, count int32, buffer unsafe.Pointer, instances int32) {
+	rlDrawVertexArrayElementsInstanced(offset, count, buffer, instances)
 }
 
 // LoadTextureDepth - Load depth texture/renderbuffer (to be attached to fbo)

--- a/raylib/rlgl_purego.go
+++ b/raylib/rlgl_purego.go
@@ -788,7 +788,6 @@ func LoadVertexBuffer[T any](buffer []T, dynamic bool) uint32 {
 	if len(buffer) == 0 {
 		return 0
 	}
-	var z T
 	size := int32(int(unsafe.Sizeof(buffer[0])) * len(buffer))
 	return rlLoadVertexBuffer(unsafe.Pointer(&buffer[0]), size, dynamic)
 }
@@ -798,7 +797,6 @@ func LoadVertexBufferElement[T any](buffer []T, dynamic bool) uint32 {
 	if len(buffer) == 0 {
 		return 0
 	}
-	var z T
 	size := int32(int(unsafe.Sizeof(buffer[0])) * len(buffer))
 	return rlLoadVertexBufferElement(unsafe.Pointer(&buffer[0]), size, dynamic)
 }
@@ -808,7 +806,6 @@ func UpdateVertexBuffer[T any](bufferId uint32, data []T, offset int32) {
 	if len(data) == 0 {
 		return
 	}
-	var z T
 	dataSize := int32(int(unsafe.Sizeof(data[0])) * len(data))
 	rlUpdateVertexBuffer(bufferId, unsafe.Pointer(&data[0]), dataSize, offset)
 }
@@ -818,7 +815,6 @@ func UpdateVertexBufferElements[T any](id uint32, data []T, offset int32) {
 	if len(data) == 0 {
 		return
 	}
-	var z T
 	dataSize := int32(int(unsafe.Sizeof(z)) * len(data))
 	rlUpdateVertexBufferElements(id, unsafe.Pointer(&data[0]), dataSize, offset)
 }

--- a/raylib/rlgl_utils.go
+++ b/raylib/rlgl_utils.go
@@ -1,0 +1,153 @@
+package rl
+
+import (
+	"fmt"
+	"reflect"
+	"unsafe"
+)
+
+// VertexAttributesConfig is used by SetVertexAttributes to specify VAO bindings for a slice of structs.
+type VertexAttributesConfig struct {
+	Field      string // Name of the field in the struct (ignored when slice is backed by an array instead of struct [][2]float32)
+	Attribute  uint32 // OpenGL attribute index (layout location)
+	Normalized bool   // Whether the attribute should be normalized
+}
+
+// SetVertexAttributes can automatically define VAO bindings for a slice of structs or slice of 1d arrays, with supported primitive types.
+// Supported primitives: float32, float64m and signed/unsigned integers (except int, int64),
+// NOTE: bind VAO and VBO before calling this.
+//
+// If a slice of structs is passed []VertexStruct:
+// The struct can contain primitives, or an array of primtives, or a struct that's
+// made out of the same primitve for every field.
+//
+//	type VertexStruct struct{
+//		Position rl.Vector3 // has same primitive type for all fields (float32), hence allowed.
+//		Color [4]byte       // array of 4 bytes. Also allowed.
+//		BlockId uint8       // a primitive. Allowed
+//	}
+//	var Vertices := [][4]float32{} // allowed. Slice of array of primitives.
+func SetVertexAttributes[T any](vertices []T, attributes []VertexAttributesConfig) {
+	if len(vertices) == 0 {
+		return
+	}
+	// Get reflect.Type of the struct
+	var zero T
+	// reflect.TypeFor but for go 1.21
+	t := reflect.TypeOf((*T)(nil)).Elem()
+	// Compute stride (size of one vertex in bytes)
+	stride := int32(unsafe.Sizeof(zero))
+	kind := t.Kind()
+
+	switch kind {
+	default:
+		panic("Vertex array is using unsupported types. Only structs and and arrays are supported.")
+	case reflect.Array: // slice of arrays eg. [][2]float32
+		arrayKind := t.Elem().Kind()               // backing type of the array. eg. float32
+		attrType, isPrimitive := glType(arrayKind) // convert to GL type.
+
+		if !isPrimitive { // type could not be converted because unsupported by GL
+			panic("Backing type for array is not one of the supported primitives " + t.Elem().String())
+		}
+		components := int32(t.Len())     // each attribute has same number of components (len of array)
+		attributeSize := t.Elem().Size() //each attribute has same size.
+
+		// iterate over each vertex attribute.
+		for i, attr := range attributes {
+			offset := int32(i) * int32(attributeSize) // manually calculate offset
+			// call OpenGL to define this vertex attribute
+			SetVertexAttribute(attr.Attribute, components, attrType, attr.Normalized, stride, offset)
+			EnableVertexAttribute(attr.Attribute)
+		}
+	//* A struct can contain:
+	// a primtive
+	// an array of primitives
+	// a struct that's made out of the same primtives for every field (basically a named array)
+	case reflect.Struct:
+		// Iterate over each attribute configuration
+		for _, attr := range attributes {
+			// Find the field by name
+			field, ok := t.FieldByName(attr.Field)
+			if !ok {
+				panic(fmt.Sprintf("struct %s does not have a field of the name %s", t.String(), attr.Field))
+			}
+
+			// Check if the field is a primitive type (float32, uint8, etc.)
+			attrType, isPrimitiveType := glType(field.Type.Kind())
+			if isPrimitiveType {
+				components := int32(1)
+				offset := int32(field.Offset)
+
+				// call OpenGL to define this vertex attribute
+				SetVertexAttribute(attr.Attribute, components, attrType, attr.Normalized, stride, offset)
+				EnableVertexAttribute(attr.Attribute)
+				continue
+			}
+			// Field is not a primitive. Check if the field is an array of primitives.
+			switch field.Type.Kind() {
+			case reflect.Array:
+				// Array of primitive types
+				elemKind := field.Type.Elem().Kind()
+				components := int32(field.Type.Len())
+				offset := int32(field.Offset)
+				attrType, isPrimitiveType := glType(elemKind) // check if array of primitives.
+				if !isPrimitiveType {
+					panic(fmt.Sprint("Only array of primitive types is supported. Got ", elemKind.String(), " for field ", attr.Field))
+				}
+				// call OpenGL
+				SetVertexAttribute(attr.Attribute, components, attrType, attr.Normalized, stride, offset)
+				EnableVertexAttribute(attr.Attribute)
+			// field is not an array of primitives. Is it a struct instead?
+			// Each field in this child struct must be of the same primitive type.
+			// The child struct is basically treated like an array.
+			case reflect.Struct:
+				components := int32(field.Type.NumField()) // how many primitives?
+				if components == 0 {
+					panic(fmt.Sprintf("Child struct %s is empty in field %s", field.Type.String(), attr.Field))
+				}
+				// Child struct: ensure all fields are the same primitive type
+				prevType := field.Type.Field(0).Type
+				attrType, isPrimitiveType := glType(prevType.Kind())
+				offset := int32(field.Offset) // offset of this field within the vertex
+
+				if !isPrimitiveType {
+					panic(fmt.Sprintf("child struct must have a primitive type for every field in %s %s", attr.Field, prevType.String()))
+				}
+
+				// Check that all child struct fields have the same type
+				for i := 1; i < field.Type.NumField(); i++ {
+					if prevType != field.Type.Field(i).Type {
+						panic(fmt.Sprintf("child struct must have the same type for every field in %s %s", attr.Field, field.Type.String()))
+					}
+				}
+
+				// call OpenGL
+				SetVertexAttribute(attr.Attribute, components, attrType, attr.Normalized, stride, offset)
+				EnableVertexAttribute(attr.Attribute)
+			}
+		}
+	}
+}
+
+func glType(k reflect.Kind) (t int32, ok bool) {
+	switch k {
+	case reflect.Int8:
+		return Byte, true
+	case reflect.Uint8:
+		return UnsignedByte, true
+	case reflect.Int16:
+		return Short, true
+	case reflect.Uint16:
+		return UnsignedShort, true
+	case reflect.Int32:
+		return Int, true
+	case reflect.Uint32:
+		return UnsignedInt, true
+	case reflect.Float32:
+		return Float, true
+	case reflect.Float64:
+		return Double, true
+	default:
+		return -1, false
+	}
+}

--- a/raylib/rlgl_utils.go
+++ b/raylib/rlgl_utils.go
@@ -31,12 +31,10 @@ func SetVertexAttributes[T any](vertices []T, attributes []VertexAttributesConfi
 	if len(vertices) == 0 {
 		return
 	}
-	// Get reflect.Type of the struct
-	var zero T
 	// reflect.TypeFor but for go 1.21
 	t := reflect.TypeOf((*T)(nil)).Elem()
 	// Compute stride (size of one vertex in bytes)
-	stride := int32(unsafe.Sizeof(vertices[0))
+	stride := int32(unsafe.Sizeof(vertices[0]))
 	kind := t.Kind()
 
 	switch kind {

--- a/raylib/rlgl_utils.go
+++ b/raylib/rlgl_utils.go
@@ -6,7 +6,7 @@ import (
 	"unsafe"
 )
 
-// VertexAttributesConfig is used by SetVertexAttributes to specify VAO bindings for a slice of structs.
+// VertexAttributesConfig is used by [SetVertexAttributes] to specify VAO bindings for a slice of structs or arrays.
 type VertexAttributesConfig struct {
 	Field      string // Name of the field in the struct (ignored when slice is backed by an array instead of struct [][2]float32)
 	Attribute  uint32 // OpenGL attribute index (layout location)
@@ -36,7 +36,7 @@ func SetVertexAttributes[T any](vertices []T, attributes []VertexAttributesConfi
 	// reflect.TypeFor but for go 1.21
 	t := reflect.TypeOf((*T)(nil)).Elem()
 	// Compute stride (size of one vertex in bytes)
-	stride := int32(unsafe.Sizeof(zero))
+	stride := int32(unsafe.Sizeof(vertices[0))
 	kind := t.Kind()
 
 	switch kind {


### PR DESCRIPTION
# Summery
  - Add Go bindings for rlgl vertex buffer management functions (`LoadVertexBuffer`, `LoadVertexBufferElement`, `UpdateVertexBuffer`, `UpdateVertexBufferElements`)
  
  
  - Add Go bindings for vertex attribute configuration (`SetVertexAttribute`, `SetVertexAttributeDefault`)
  
  
  - Add Go bindings for draw array functions (`DrawVertexArray`, `DrawVertexArrayElements`, `DrawVertexArrayInstanced`, `DrawVertexArrayElementsInstanced`)
  
  
  - Implementations for both cgo and purego backends 
  -- Note: I dont actually know how purego works so just copied what I saw the other implementation looked like (someone else might want to take a look)
  
  
  - Include an example (`examples/others/rlgl_vertex_buffer`) demonstrating indexed and non-indexed draws with animated vertex colors 
  -- Note: It dosnt test the Instanced version of `DrawVertexArrayInstanced`, `DrawVertexArrayElementsInstanced` but I would be surprised if they don't work. Also I did this change to speed up my entity renderer to get over 400K entities on screen, so I'll be testing those when I implement this into that project  
  
  
  
  # Example

|               |                                           |
|------------|-------------------------------------------|
| **OS**     | Arch Linux (rolling)                      |
| **Kernel** | 6.18.6-arch1-1                            |
| **Arch**   | x86_64                                    |
| **CPU**    | AMD Ryzen AI 7 350 |
| **GPU**    | AMD Radeon 860M                           |
| **Go**     | 1.25.6 (linux/amd64)                      |

<img width="1426" height="906" alt="image" src="https://github.com/user-attachments/assets/0cdf2597-7c4d-41cf-8d97-1561a2d154e4" />

