### PR TITLE
Fixes LoadVBE func name typo

### DIFF
--- a/examples/others/rlgl_instanced_quads/main.go
+++ b/examples/others/rlgl_instanced_quads/main.go
@@ -1,5 +1,5 @@
 // This example demonstrates instanced drawing with low-level rlgl bindings:
-//   - LoadVertexBufferElements: upload index data (EBO) to GPU
+//   - LoadVertexBufferElement: upload index data (EBO) to GPU
 //   - DrawVertexArrayElementsInstanced: instanced indexed draw
 //   - SetVertexAttributeDivisor: per-instance attribute advancement
 //   - Camera3D with BeginMode3D/EndMode3D for orbital 3D camera control
@@ -133,7 +133,7 @@ func main() {
 	rl.SetVertexAttributeDivisor(3, 1)
 
 	// Index buffer (EBO)
-	ebo := rl.LoadVertexBufferElements(quadIndices, false)
+	ebo := rl.LoadVertexBufferElement(quadIndices, false)
 	defer rl.UnloadVertexBuffer(ebo)
 
 	rl.DisableVertexArray()

--- a/examples/others/rlgl_vertex_buffer/main.go
+++ b/examples/others/rlgl_vertex_buffer/main.go
@@ -91,7 +91,7 @@ func main() {
 	rl.EnableVertexAttribute(3)
 
 	// Index buffer (EBO) (for indexed drawing of vertices)
-	quadIBO := rl.LoadVertexBufferElements(quadIndices, false)
+	quadIBO := rl.LoadVertexBufferElement(quadIndices, false)
 	defer rl.UnloadVertexBuffer(quadIBO)
 	rl.DisableVertexArray() // disable quadVAO that was enabled on creation.
 
@@ -152,7 +152,7 @@ func main() {
 
 	// Orthographic projection: screen-space coordinates, origin top-left
 	// NOTE: rl.MatrixMultiply(rl.GetMatrixModelview(), rl.GetMatrixProjection()) could be used to work with rl camera
-  // See examples/others/rlgl_instanced_quad/main.go
+	// See examples/others/rlgl_instanced_quad/main.go
 	mvpMatrix := rl.MatrixOrtho(0, screenWidth, screenHeight, 0, -1, 1)
 
 	// White diffuse color so vertex colors pass through unmodified

--- a/raylib/rlgl_cgo.go
+++ b/raylib/rlgl_cgo.go
@@ -631,8 +631,8 @@ func LoadVertexBuffer[T any](buffer []T, dynamic bool) uint32 {
 	return uint32(C.rlLoadVertexBuffer(cbuffer, csize, cdynamic))
 }
 
-// LoadVertexBufferElements - Load vertex buffer elements object
-func LoadVertexBufferElements[T any](buffer []T, dynamic bool) uint32 {
+// LoadVertexBufferElement - Load vertex buffer elements object
+func LoadVertexBufferElement[T any](buffer []T, dynamic bool) uint32 {
 	if len(buffer) == 0 {
 		return 0
 	}


### PR DESCRIPTION
I was exploring the latest rlgl bindings added and the `LoadVertexBufferElements` calls from both examples were not found on compilation, despite my IDE saying it was valid. Did some digging to find the name disparity. Removing the `s` compiled but made the IDE syntax checking upset. Hopefully this is the right fix.