### PR TITLE
Make the raygui API consistent with raygui.h

### DIFF
--- a/examples/easings/easings/main.go
+++ b/examples/easings/easings/main.go
@@ -77,7 +77,7 @@ func main() {
 		rl.ClearBackground(rl.RayWhite)
 
 		raygui.Label(rl.NewRectangle(20, 20, 200, 20), "Easing Type:")
-		comboActive = raygui.ComboBox(rl.NewRectangle(20, 40, 200, 20), strings.Join(easingTypes, ";"), comboActive)
+		raygui.ComboBox(rl.NewRectangle(20, 40, 200, 20), strings.Join(easingTypes, ";"), &comboActive)
 
 		raygui.Label(rl.NewRectangle(20, 80, 200, 20), "Press R to reset")
 

--- a/examples/gui/controls_test_suite/controls_test_suite.go
+++ b/examples/gui/controls_test_suite/controls_test_suite.go
@@ -99,7 +99,7 @@ func main() {
 
 		toggleGroupActive int32 = 0
 
-		viewScroll = rl.Vector2{0, 0}
+		viewScroll = rl.NewVector2(0, 0)
 
 		//----------------------------------------------------------------------------------
 
@@ -159,86 +159,86 @@ func main() {
 
 		// First GUI column
 		//GuiSetStyle(CHECKBOX, TEXT_ALIGNMENT, TEXT_ALIGN_LEFT);
-		forceSquaredChecked = gui.CheckBox(rl.Rectangle{25, 108, 15, 15}, "FORCE CHECK!", forceSquaredChecked)
+		gui.CheckBox(rl.NewRectangle(25, 108, 15, 15), "FORCE CHECK!", &forceSquaredChecked)
 
 		gui.SetStyle(gui.TEXTBOX, gui.TEXT_ALIGNMENT, gui.TEXT_ALIGN_CENTER)
 		//GuiSetStyle(VALUEBOX, TEXT_ALIGNMENT, TEXT_ALIGN_LEFT);
-		gui.Spinner(rl.Rectangle{25, 135, 125, 30}, "", &spinner001Value, 0, 100, spinnerEditMode)
+		gui.Spinner(rl.NewRectangle(25, 135, 125, 30), "", &spinner001Value, 0, 100, spinnerEditMode)
 
-		if gui.ValueBox(rl.Rectangle{25, 175, 125, 30}, "", &valueBox002Value, 0, 100, valueBoxEditMode) {
+		if gui.ValueBox(rl.NewRectangle(25, 175, 125, 30), "", &valueBox002Value, 0, 100, valueBoxEditMode) {
 			valueBoxEditMode = !valueBoxEditMode
 		}
 		gui.SetStyle(gui.TEXTBOX, gui.TEXT_ALIGNMENT, gui.TEXT_ALIGN_LEFT)
-		if gui.TextBox(rl.Rectangle{25, 215, 125, 30}, &textBoxText, 64, textBoxEditMode) {
+		if gui.TextBox(rl.NewRectangle(25, 215, 125, 30), &textBoxText, 64, textBoxEditMode) {
 			textBoxEditMode = !textBoxEditMode
 		}
 
 		gui.SetStyle(gui.BUTTON, gui.TEXT_ALIGNMENT, gui.TEXT_ALIGN_CENTER)
 
-		if gui.Button(rl.Rectangle{25, 255, 125, 30}, gui.IconText(gui.ICON_FILE_SAVE, "Save File")) {
+		if gui.Button(rl.NewRectangle(25, 255, 125, 30), gui.IconText(gui.ICON_FILE_SAVE, "Save File")) {
 			showTextInputBox = true
 		}
 
-		gui.GroupBox(rl.Rectangle{25, 310, 125, 150}, "STATES")
+		gui.GroupBox(rl.NewRectangle(25, 310, 125, 150), "STATES")
 		//GuiLock();
 		gui.SetState(gui.STATE_NORMAL)
-		if gui.Button(rl.Rectangle{30, 320, 115, 30}, "NORMAL") {
+		if gui.Button(rl.NewRectangle(30, 320, 115, 30), "NORMAL") {
 		}
 		gui.SetState(gui.STATE_FOCUSED)
-		if gui.Button(rl.Rectangle{30, 355, 115, 30}, "FOCUSED") {
+		if gui.Button(rl.NewRectangle(30, 355, 115, 30), "FOCUSED") {
 		}
 		gui.SetState(gui.STATE_PRESSED)
-		if gui.Button(rl.Rectangle{30, 390, 115, 30}, "#15#PRESSED") {
+		if gui.Button(rl.NewRectangle(30, 390, 115, 30), "#15#PRESSED") {
 		}
 		gui.SetState(gui.STATE_DISABLED)
-		if gui.Button(rl.Rectangle{30, 425, 115, 30}, "DISABLED") {
+		if gui.Button(rl.NewRectangle(30, 425, 115, 30), "DISABLED") {
 		}
 		gui.SetState(gui.STATE_NORMAL)
 		//GuiUnlock();
 
-		comboBoxActive = gui.ComboBox(rl.Rectangle{25, 470, 125, 30}, "ONE;TWO;THREE;FOUR", comboBoxActive)
+		gui.ComboBox(rl.NewRectangle(25, 470, 125, 30), "ONE;TWO;THREE;FOUR", &comboBoxActive)
 
 		// NOTE: gui.DropdownBox must draw after any other control that can be covered on unfolding
 		gui.SetStyle(gui.DROPDOWNBOX, gui.TEXT_ALIGNMENT, gui.TEXT_ALIGN_LEFT)
-		if gui.DropdownBox(rl.Rectangle{25, 65, 125, 30}, "#01#ONE;#02#TWO;#03#THREE;#04#FOUR", &dropdownBox001Active, dropDown001EditMode) {
+		if gui.DropdownBox(rl.NewRectangle(25, 65, 125, 30), "#01#ONE;#02#TWO;#03#THREE;#04#FOUR", &dropdownBox001Active, dropDown001EditMode) {
 			dropDown001EditMode = !dropDown001EditMode
 		}
 
 		gui.SetStyle(gui.DROPDOWNBOX, gui.TEXT_ALIGNMENT, gui.TEXT_ALIGN_CENTER)
-		if gui.DropdownBox(rl.Rectangle{25, 25, 125, 30}, "ONE;TWO;THREE", &dropdownBox000Active, dropDown000EditMode) {
+		if gui.DropdownBox(rl.NewRectangle(25, 25, 125, 30), "ONE;TWO;THREE", &dropdownBox000Active, dropDown000EditMode) {
 			dropDown000EditMode = !dropDown000EditMode
 		}
 
 		// Second GUI column
-		listViewActive = gui.ListView(rl.Rectangle{165, 25, 140, 140}, "Charmander;Bulbasaur;#18#Squirtel;Pikachu;Eevee;Pidgey", &listViewScrollIndex, listViewActive)
-		listViewExActive = gui.ListViewEx(rl.Rectangle{165, 180, 140, 200}, listViewExList, &listViewExFocus, &listViewExScrollIndex, listViewExActive)
+		gui.ListView(rl.NewRectangle(165, 25, 140, 140), "Charmander;Bulbasaur;#18#Squirtel;Pikachu;Eevee;Pidgey", &listViewScrollIndex, &listViewActive)
+		gui.ListViewEx(rl.NewRectangle(165, 180, 140, 200), listViewExList, &listViewExFocus, &listViewExScrollIndex, &listViewExActive)
 
-		toggleGroupActive = gui.ToggleGroup(rl.Rectangle{165, 400, 140, 25}, "#1#ONE\n#3#TWO\n#8#THREE\n#23#", toggleGroupActive)
+		gui.ToggleGroup(rl.NewRectangle(165, 400, 140, 25), "#1#ONE\n#3#TWO\n#8#THREE\n#23#", &toggleGroupActive)
 
 		// Third GUI column
 		gui.Panel(rl.NewRectangle(320, 25, 225, 140), "Panel Info")
-		colorPickerValue = gui.ColorPicker(rl.Rectangle{320, 185, 196, 192}, "", colorPickerValue)
+		gui.ColorPicker(rl.NewRectangle(320, 185, 196, 192), "", &colorPickerValue)
 
-		sliderValue = gui.Slider(rl.Rectangle{355, 400, 165, 20}, "TEST",
-			fmt.Sprintf("%2.2f", sliderValue), sliderValue, -50, 100)
-		sliderBarValue = gui.SliderBar(rl.Rectangle{320, 430, 200, 20}, "",
-			fmt.Sprintf("%2.2f", sliderBarValue), sliderBarValue, 0, 100)
-		progressValue = gui.ProgressBar(rl.Rectangle{320, 460, 200, 20}, "", "", progressValue, 0, 1)
+		gui.Slider(rl.NewRectangle(355, 400, 165, 20), "TEST",
+			fmt.Sprintf("%2.2f", sliderValue), &sliderValue, -50, 100)
+		gui.SliderBar(rl.NewRectangle(320, 430, 200, 20), "",
+			fmt.Sprintf("%2.2f", sliderBarValue), &sliderBarValue, 0, 100)
+		gui.ProgressBar(rl.NewRectangle(320, 460, 200, 20), "", "", &progressValue, 0, 1)
 
 		// NOTE: View rectangle could be used to perform some scissor test
 		var view rl.Rectangle
-		gui.ScrollPanel(rl.Rectangle{560, 25, 102, 354}, "", rl.Rectangle{560, 25, 300, 1200}, &viewScroll, &view)
+		gui.ScrollPanel(rl.NewRectangle(560, 25, 102, 354), "", rl.NewRectangle(560, 25, 300, 1200), &viewScroll, &view)
 
 		var mouseCell rl.Vector2
-		gui.Grid(rl.Rectangle{560, 25 + 180 + 195, 100, 120}, "", 20, 3, &mouseCell)
+		gui.Grid(rl.NewRectangle(560, 25 + 180 + 195, 100, 120), "", 20, 3, &mouseCell)
 
-		alphaValue = gui.ColorBarAlpha(rl.Rectangle{320, 490, 200, 30}, "", alphaValue)
+		gui.ColorBarAlpha(rl.NewRectangle(320, 490, 200, 30), "", &alphaValue)
 
-		gui.StatusBar(rl.Rectangle{0, float32(rl.GetScreenHeight()) - 20, float32(rl.GetScreenWidth()), 20}, "This is a status bar")
+		gui.StatusBar(rl.NewRectangle(0, float32(rl.GetScreenHeight()) - 20, float32(rl.GetScreenWidth()), 20), "This is a status bar")
 
 		if showMessageBox {
 			rl.DrawRectangle(0, 0, int32(rl.GetScreenWidth()), int32(rl.GetScreenHeight()), rl.Fade(rl.RayWhite, 0.8))
-			var result int32 = gui.MessageBox(rl.Rectangle{float32(rl.GetScreenWidth())/2 - 125, float32(rl.GetScreenHeight())/2 - 50, 250, 100}, gui.IconText(gui.ICON_EXIT, "Close Window"), "Do you really want to exit?", "Yes;No")
+			var result int32 = gui.MessageBox(rl.NewRectangle(float32(rl.GetScreenWidth())/2 - 125, float32(rl.GetScreenHeight())/2 - 50, 250, 100), gui.IconText(gui.ICON_EXIT, "Close Window"), "Do you really want to exit?", "Yes;No")
 
 			if (result == 0) || (result == 2) {
 				showMessageBox = false
@@ -251,7 +251,7 @@ func main() {
 			rl.DrawRectangle(0, 0, int32(rl.GetScreenWidth()), int32(rl.GetScreenHeight()), rl.Fade(rl.RayWhite, 0.8))
 			var secretViewActive bool
 			var result int32 = gui.TextInputBox(
-				rl.Rectangle{float32(rl.GetScreenWidth())/2 - 120, float32(rl.GetScreenHeight())/2 - 60, 240, 140},
+				rl.NewRectangle(float32(rl.GetScreenWidth())/2 - 120, float32(rl.GetScreenHeight())/2 - 60, 240, 140),
 				"Save",
 				gui.IconText(gui.ICON_FILE_SAVE, "Save file as..."),
 				"Ok;Cancel",

--- a/examples/gui/portable_window/portable_window.go
+++ b/examples/gui/portable_window/portable_window.go
@@ -40,8 +40,8 @@ func main() {
 
 	// General variables
 	var (
-		mousePosition  = rl.Vector2{0, 0}
-		windowPosition = rl.Vector2{500, 200}
+		mousePosition  = rl.NewVector2(0, 0)
+		windowPosition = rl.NewVector2(500, 200)
 		panOffset      = mousePosition
 		dragWindow     = false
 	)
@@ -60,7 +60,7 @@ func main() {
 		mousePosition = rl.GetMousePosition()
 
 		if rl.IsMouseButtonPressed(rl.MouseLeftButton) {
-			if (rl.CheckCollisionPointRec(mousePosition, rl.Rectangle{0, 0, screenWidth, 20})) {
+			if (rl.CheckCollisionPointRec(mousePosition, rl.NewRectangle(0, 0, screenWidth, 20))) {
 				dragWindow = true
 				panOffset = mousePosition
 			}
@@ -84,7 +84,7 @@ func main() {
 
 		rl.ClearBackground(rl.RayWhite)
 
-		exitWindow = gui.WindowBox(rl.Rectangle{0, 0, screenWidth, screenHeight}, "#198# PORTABLE WINDOW")
+		exitWindow = gui.WindowBox(rl.NewRectangle(0, 0, screenWidth, screenHeight), "#198# PORTABLE WINDOW")
 
 		rl.DrawText(fmt.Sprintf("Mouse Position: [ %.0f, %.0f ]", mousePosition.X, mousePosition.Y), 10, 40, 10, rl.DarkGray)
 

--- a/examples/gui/scroll_panel/scroll_panel.go
+++ b/examples/gui/scroll_panel/scroll_panel.go
@@ -45,11 +45,11 @@ func main() {
 	rl.InitWindow(screenWidth, screenHeight, "raygui - gui.ScrollPanel()")
 
 	var (
-		panelRec        = rl.Rectangle{20, 40, 200, 150}
-		panelContentRec = rl.Rectangle{0, 0, 340, 340}
-		panelView       = rl.Rectangle{0, 0, 0, 0}
-		panelScroll     = rl.Vector2{99, -20}
-		mouseCell       = rl.Vector2{0, 0}
+		panelRec        = rl.NewRectangle(20, 40, 200, 150)
+		panelContentRec = rl.NewRectangle(0, 0, 340, 340)
+		panelView       = rl.NewRectangle(0, 0, 0, 0)
+		panelScroll     = rl.NewVector2(99, -20)
+		mouseCell       = rl.NewVector2(0, 0)
 
 		showContentArea = true
 	)
@@ -77,12 +77,12 @@ func main() {
 		gui.ScrollPanel(panelRec, "", panelContentRec, &panelScroll, &panelView)
 
 		rl.BeginScissorMode(int32(panelView.X), int32(panelView.Y), int32(panelView.Width), int32(panelView.Height))
-		gui.Grid(rl.Rectangle{
-			float32(panelRec.X + panelScroll.X),
-			float32(panelRec.Y + panelScroll.Y),
+		gui.Grid(rl.NewRectangle(
+			float32(panelRec.X+panelScroll.X),
+			float32(panelRec.Y+panelScroll.Y),
 			float32(panelContentRec.Width),
 			float32(panelContentRec.Height),
-		}, "", 16, 3, &mouseCell)
+		), "", 16, 3, &mouseCell)
 		rl.EndScissorMode()
 
 		if showContentArea {
@@ -97,17 +97,17 @@ func main() {
 
 		DrawStyleEditControls()
 
-		showContentArea = gui.CheckBox(rl.Rectangle{565, 80, 20, 20}, "SHOW CONTENT AREA", showContentArea)
+		gui.CheckBox(rl.NewRectangle(565, 80, 20, 20), "SHOW CONTENT AREA", &showContentArea)
 
-		panelContentRec.Width = gui.SliderBar(rl.Rectangle{590, 385, 145, 15},
+		gui.SliderBar(rl.NewRectangle(590, 385, 145, 15),
 			"WIDTH",
 			fmt.Sprintf("%.1f", panelContentRec.Width),
-			panelContentRec.Width,
+			&panelContentRec.Width,
 			1, 600)
-		panelContentRec.Height = gui.SliderBar(rl.Rectangle{590, 410, 145, 15},
+		gui.SliderBar(rl.NewRectangle(590, 410, 145, 15),
 			"HEIGHT",
 			fmt.Sprintf("%.1f", panelContentRec.Height),
-			panelContentRec.Height, 1, 400)
+			&panelContentRec.Height, 1, 400)
 
 		rl.EndDrawing()
 		//----------------------------------------------------------------------------------
@@ -123,36 +123,40 @@ func main() {
 func DrawStyleEditControls() {
 	// ScrollPanel style controls
 	//----------------------------------------------------------
-	gui.GroupBox(rl.Rectangle{550, 170, 220, 205}, "SCROLLBAR STYLE")
+	gui.GroupBox(rl.NewRectangle(550, 170, 220, 205), "SCROLLBAR STYLE")
 
 	var style int32
+	var checked bool
+	var side bool
 
 	style = int32(gui.GetStyle(gui.SCROLLBAR, gui.BORDER_WIDTH))
-	gui.Label(rl.Rectangle{555, 195, 110, 10}, "BORDER_WIDTH")
-	gui.Spinner(rl.Rectangle{670, 190, 90, 20}, "", &style, 0, 6, false)
+	gui.Label(rl.NewRectangle(555, 195, 110, 10), "BORDER_WIDTH")
+	gui.Spinner(rl.NewRectangle(670, 190, 90, 20), "", &style, 0, 6, false)
 	gui.SetStyle(gui.SCROLLBAR, gui.BORDER_WIDTH, gui.PropertyValue(style))
 
 	style = int32(gui.GetStyle(gui.SCROLLBAR, gui.ARROWS_SIZE))
-	gui.Label(rl.Rectangle{555, 220, 110, 10}, "ARROWS_SIZE")
-	gui.Spinner(rl.Rectangle{670, 215, 90, 20}, "", &style, 4, 14, false)
+	gui.Label(rl.NewRectangle(555, 220, 110, 10), "ARROWS_SIZE")
+	gui.Spinner(rl.NewRectangle(670, 215, 90, 20), "", &style, 4, 14, false)
 	gui.SetStyle(gui.SCROLLBAR, gui.ARROWS_SIZE, gui.PropertyValue(style))
 
 	style = int32(gui.GetStyle(gui.SCROLLBAR, gui.SCROLL_PADDING))
-	gui.Label(rl.Rectangle{555, 245, 110, 10}, "SCROLL_PADDING")
-	gui.Spinner(rl.Rectangle{670, 240, 90, 20}, "", &style, 0, 14, false)
+	gui.Label(rl.NewRectangle(555, 245, 110, 10), "SCROLL_PADDING")
+	gui.Spinner(rl.NewRectangle(670, 240, 90, 20), "", &style, 0, 14, false)
 	gui.SetStyle(gui.SCROLLBAR, gui.SCROLL_PADDING, gui.PropertyValue(style))
 
-	style = boolToint32(gui.CheckBox(rl.Rectangle{565, 280, 20, 20}, "ARROWS_VISIBLE", int32Tobool(int32(gui.GetStyle(gui.SCROLLBAR, gui.ARROWS_VISIBLE)))))
-	gui.SetStyle(gui.SCROLLBAR, gui.ARROWS_VISIBLE, gui.PropertyValue(style))
+	style = int32(gui.GetStyle(gui.SCROLLBAR, gui.ARROWS_VISIBLE))
+	checked = int32Tobool(style)
+	gui.CheckBox(rl.NewRectangle(565, 280, 20, 20), "ARROWS_VISIBLE", &checked)
+	gui.SetStyle(gui.SCROLLBAR, gui.ARROWS_VISIBLE, gui.PropertyValue(boolToint32(checked)))
 
 	style = int32(gui.GetStyle(gui.SLIDER, gui.SLIDER_PADDING))
-	gui.Label(rl.Rectangle{555, 325, 110, 10}, "SLIDER_PADDING")
-	gui.Spinner(rl.Rectangle{670, 320, 90, 20}, "", &style, 0, 14, false)
+	gui.Label(rl.NewRectangle(555, 325, 110, 10), "SLIDER_PADDING")
+	gui.Spinner(rl.NewRectangle(670, 320, 90, 20), "", &style, 0, 14, false)
 	gui.SetStyle(gui.SLIDER, gui.SLIDER_PADDING, gui.PropertyValue(style))
 
 	style = int32(gui.GetStyle(gui.SLIDER, gui.SLIDER_WIDTH))
-	gui.Label(rl.Rectangle{555, 350, 110, 10}, "SLIDER_WIDTH")
-	gui.Spinner(rl.Rectangle{670, 345, 90, 20}, "", &style, 2, 100, false)
+	gui.Label(rl.NewRectangle(555, 350, 110, 10), "SLIDER_WIDTH")
+	gui.Spinner(rl.NewRectangle(670, 345, 90, 20), "", &style, 2, 100, false)
 	gui.SetStyle(gui.SLIDER, gui.SLIDER_WIDTH, gui.PropertyValue(style))
 
 	var text string
@@ -161,22 +165,25 @@ func DrawStyleEditControls() {
 	} else {
 		text = "SCROLLBAR: RIGHT"
 	}
-	style = boolToint32(gui.Toggle(rl.Rectangle{560, 110, 200, 35}, text, int32Tobool(int32(gui.GetStyle(gui.LISTVIEW, gui.SCROLLBAR_SIDE)))))
-	gui.SetStyle(gui.LISTVIEW, gui.SCROLLBAR_SIDE, gui.PropertyValue(style))
+
+	style = int32(gui.GetStyle(gui.LISTVIEW, gui.SCROLLBAR_SIDE))
+	side = int32Tobool(style)
+	gui.Toggle(rl.NewRectangle(560, 110, 200, 35), text, &side)
+	gui.SetStyle(gui.LISTVIEW, gui.SCROLLBAR_SIDE, gui.PropertyValue(boolToint32(side)))
 	//----------------------------------------------------------
 
 	// ScrollBar style controls
 	//----------------------------------------------------------
-	gui.GroupBox(rl.Rectangle{550, 20, 220, 135}, "SCROLLPANEL STYLE")
+	gui.GroupBox(rl.NewRectangle(550, 20, 220, 135), "SCROLLPANEL STYLE")
 
 	style = int32(gui.GetStyle(gui.LISTVIEW, gui.SCROLLBAR_WIDTH))
-	gui.Label(rl.Rectangle{555, 35, 110, 10}, "SCROLLBAR_WIDTH")
-	gui.Spinner(rl.Rectangle{670, 30, 90, 20}, "", &style, 6, 30, false)
+	gui.Label(rl.NewRectangle(555, 35, 110, 10), "SCROLLBAR_WIDTH")
+	gui.Spinner(rl.NewRectangle(670, 30, 90, 20), "", &style, 6, 30, false)
 	gui.SetStyle(gui.LISTVIEW, gui.SCROLLBAR_WIDTH, gui.PropertyValue(style))
 
 	style = int32(gui.GetStyle(gui.LISTVIEW, gui.BORDER_WIDTH))
-	gui.Label(rl.Rectangle{555, 60, 110, 10}, "BORDER_WIDTH")
-	gui.Spinner(rl.Rectangle{670, 55, 90, 20}, "", &style, 0, 20, false)
+	gui.Label(rl.NewRectangle(555, 60, 110, 10), "BORDER_WIDTH")
+	gui.Spinner(rl.NewRectangle(670, 55, 90, 20), "", &style, 0, 20, false)
 	gui.SetStyle(gui.LISTVIEW, gui.BORDER_WIDTH, gui.PropertyValue(style))
 	//----------------------------------------------------------
 }

--- a/examples/shapes/draw_circle_sector/main.go
+++ b/examples/shapes/draw_circle_sector/main.go
@@ -51,19 +51,19 @@ func main() {
 		// Draw GUI controls
 		r := rl.Rectangle{X: 600, Y: 40, Width: 120, Height: 20}
 		msg := fmt.Sprintf("%.2f", startAngle)
-		startAngle = gui.Slider(r, "StartAngle", msg, startAngle, 0, 720)
+		gui.Slider(r, "StartAngle", msg, &startAngle, 0, 720)
 
 		r = rl.Rectangle{X: 600, Y: 70, Width: 120, Height: 20}
 		msg = fmt.Sprintf("%.2f", endAngle)
-		endAngle = gui.Slider(r, "EndAngle", msg, endAngle, 0, 720)
+		gui.Slider(r, "EndAngle", msg, &endAngle, 0, 720)
 
 		r = rl.Rectangle{X: 600, Y: 140, Width: 120, Height: 20}
 		msg = fmt.Sprintf("%.2f", outerRadius)
-		outerRadius = gui.Slider(r, "Radius", msg, outerRadius, 0, 200)
+		gui.Slider(r, "Radius", msg, &outerRadius, 0, 200)
 
 		r = rl.Rectangle{X: 600, Y: 170, Width: 120, Height: 20}
 		msg = fmt.Sprintf("%.2f", segments)
-		segments = gui.Slider(r, "Segments", msg, segments, 0, 100)
+		gui.Slider(r, "Segments", msg, &segments, 0, 100)
 
 		minSegments = calculateMinSegments(startAngle, endAngle)
 		text := "MODE: AUTO"

--- a/examples/shapes/draw_ring/main.go
+++ b/examples/shapes/draw_ring/main.go
@@ -69,33 +69,17 @@ func main() {
 
 		// Draw GUI controls
 		//------------------------------------------------------------------------------
-		startAngle = gui.Slider(rl.Rectangle{
-			X: 600, Y: 40, Width: 120, Height: 20,
-		}, "StartAngle", fmt.Sprintf("%.2f", startAngle), startAngle, -450, 450)
-		endAngle = gui.Slider(rl.Rectangle{
-			X: 600, Y: 70, Width: 120, Height: 20,
-		}, "EndAngle", fmt.Sprintf("%.2f", endAngle), endAngle, -450, 450)
+		gui.Slider(rl.NewRectangle(600, 40, 120, 20), "StartAngle", fmt.Sprintf("%.2f", startAngle), &startAngle, -450, 450)
+		gui.Slider(rl.NewRectangle(600, 70, 120, 20), "EndAngle", fmt.Sprintf("%.2f", endAngle), &endAngle, -450, 450)
 
-		innerRadius = gui.Slider(rl.Rectangle{
-			X: 600, Y: 140, Width: 120, Height: 20,
-		}, "InnerRadius", fmt.Sprintf("%.2f", innerRadius), innerRadius, 0, 100)
-		outerRadius = gui.Slider(rl.Rectangle{
-			X: 600, Y: 170, Width: 120, Height: 20,
-		}, "OuterRadius", fmt.Sprintf("%.2f", outerRadius), outerRadius, 0, 200)
+		gui.Slider(rl.NewRectangle(600, 140, 120, 20), "InnerRadius", fmt.Sprintf("%.2f", innerRadius), &innerRadius, 0, 100)
+		gui.Slider(rl.NewRectangle(600, 170, 120, 20), "OuterRadius", fmt.Sprintf("%.2f", outerRadius), &outerRadius, 0, 200)
 
-		segments = gui.Slider(rl.Rectangle{
-			X: 600, Y: 240, Width: 120, Height: 20,
-		}, "Segments", fmt.Sprintf("%.2f", segments), segments, 0, 100)
+		gui.Slider(rl.NewRectangle(600, 240, 120, 20), "Segments", fmt.Sprintf("%.2f", segments), &segments, 0, 100)
 
-		drawRing = gui.CheckBox(rl.Rectangle{
-			X: 600, Y: 320, Width: 20, Height: 20,
-		}, "Draw Ring", drawRing)
-		drawRingLines = gui.CheckBox(rl.Rectangle{
-			X: 600, Y: 350, Width: 20, Height: 20,
-		}, "Draw Ring Lines", drawRingLines)
-		drawSectorLines = gui.CheckBox(rl.Rectangle{
-			X: 600, Y: 380, Width: 20, Height: 20,
-		}, "Draw Sector Lines", drawSectorLines)
+		gui.CheckBox(rl.NewRectangle(600, 320, 20, 20), "Draw Ring", &drawRing)
+		gui.CheckBox(rl.NewRectangle(600, 350, 20, 20), "Draw Ring Lines", &drawRingLines)
+		gui.CheckBox(rl.NewRectangle(600, 380, 20, 20), "Draw Sector Lines", &drawSectorLines)
 
 		minSegments := ceil((endAngle - startAngle) / 90)
 		var color = rl.DarkGray

--- a/raygui/raygui.go
+++ b/raygui/raygui.go
@@ -28,7 +28,7 @@ func (p PropertyID) IsExtended() bool {
 }
 
 func (v PropertyValue) AsColor() rl.Color {
-	return rl.Color{uint8(v >> 24), uint8(v >> 16), uint8(v >> 8), uint8(v)}
+	return rl.Color{R: uint8(v >> 24), G: uint8(v >> 16), B: uint8(v >> 8), A: uint8(v)}
 }
 
 func NewColorPropertyValue(color rl.Color) PropertyValue {
@@ -571,11 +571,13 @@ func WindowBox(bounds rl.Rectangle, title string) bool {
 		ctitle = C.CString(title)
 		defer C.free(unsafe.Pointer(ctitle))
 	}
+
+	// NOTE: Returns the same as C.GuiButton
 	return C.GuiWindowBox(cbounds, ctitle) != 0
 }
 
 // Group Box control with text name
-func GroupBox(bounds rl.Rectangle, text string) {
+func GroupBox(bounds rl.Rectangle, text string) bool {
 	var cbounds C.struct_Rectangle
 	cbounds.height = C.float(bounds.Height)
 	cbounds.x = C.float(bounds.X)
@@ -586,11 +588,13 @@ func GroupBox(bounds rl.Rectangle, text string) {
 		ctext = C.CString(text)
 		defer C.free(unsafe.Pointer(ctext))
 	}
-	C.GuiGroupBox(cbounds, ctext)
+
+	// NOTE: This only returns 0 on raylib.h
+	return C.GuiGroupBox(cbounds, ctext) != 0
 }
 
 // Line control
-func Line(bounds rl.Rectangle, text string) {
+func Line(bounds rl.Rectangle, text string) bool {
 	var cbounds C.struct_Rectangle
 	cbounds.x = C.float(bounds.X)
 	cbounds.y = C.float(bounds.Y)
@@ -601,11 +605,13 @@ func Line(bounds rl.Rectangle, text string) {
 		ctext = C.CString(text)
 		defer C.free(unsafe.Pointer(ctext))
 	}
-	C.GuiLine(cbounds, ctext)
+
+	// NOTE: This only returns 0 on raylib.h
+	return C.GuiLine(cbounds, ctext) != 0
 }
 
 // Panel control
-func Panel(bounds rl.Rectangle, text string) {
+func Panel(bounds rl.Rectangle, text string) bool {
 	var cbounds C.struct_Rectangle
 	cbounds.width = C.float(bounds.Width)
 	cbounds.height = C.float(bounds.Height)
@@ -616,7 +622,9 @@ func Panel(bounds rl.Rectangle, text string) {
 		ctext = C.CString(text)
 		defer C.free(unsafe.Pointer(ctext))
 	}
-	C.GuiPanel(cbounds, ctext)
+
+	// NOTE: This only returns 0 on raylib.h
+	return C.GuiPanel(cbounds, ctext) != 0
 }
 
 // Tab Bar control, returns the current TAB closing requested, -1 otherwise
@@ -643,7 +651,7 @@ func TabBar(bounds rl.Rectangle, text []string, active *int32) int32 {
 }
 
 // Scroll Panel control
-func ScrollPanel(bounds rl.Rectangle, text string, content rl.Rectangle, scroll *rl.Vector2, view *rl.Rectangle) {
+func ScrollPanel(bounds rl.Rectangle, text string, content rl.Rectangle, scroll *rl.Vector2, view *rl.Rectangle) bool {
 	var cbounds C.struct_Rectangle
 	cbounds.x = C.float(bounds.X)
 	cbounds.y = C.float(bounds.Y)
@@ -678,11 +686,12 @@ func ScrollPanel(bounds rl.Rectangle, text string, content rl.Rectangle, scroll 
 		view.Height = float32(cview.height)
 	}()
 
-	C.GuiScrollPanel(cbounds, ctext, ccontent, &cscroll, &cview)
+	// NOTE: This only returns 0 on raylib.h
+	return C.GuiScrollPanel(cbounds, ctext, ccontent, &cscroll, &cview) != 0
 }
 
 // Label control
-func Label(bounds rl.Rectangle, text string) {
+func Label(bounds rl.Rectangle, text string) bool {
 	var cbounds C.struct_Rectangle
 	cbounds.x = C.float(bounds.X)
 	cbounds.y = C.float(bounds.Y)
@@ -693,7 +702,9 @@ func Label(bounds rl.Rectangle, text string) {
 		ctext = C.CString(text)
 		defer C.free(unsafe.Pointer(ctext))
 	}
-	C.GuiLabel(cbounds, ctext)
+
+	// NOTE: This only returns 0 on raylib.h
+	return C.GuiLabel(cbounds, ctext) != 0
 }
 
 // Button control, returns true when clicked
@@ -727,7 +738,7 @@ func LabelButton(bounds rl.Rectangle, text string) bool {
 }
 
 // Toggle control, returns true when active
-func Toggle(bounds rl.Rectangle, text string, active bool) bool {
+func Toggle(bounds rl.Rectangle, text string, active *bool) bool {
 	var cbounds C.struct_Rectangle
 	cbounds.x = C.float(bounds.X)
 	cbounds.y = C.float(bounds.Y)
@@ -738,13 +749,21 @@ func Toggle(bounds rl.Rectangle, text string, active bool) bool {
 		ctext = C.CString(text)
 		defer C.free(unsafe.Pointer(ctext))
 	}
-	cactive := C.bool(active)
-	C.GuiToggle(cbounds, ctext, &cactive)
-	return bool(cactive)
+
+	if active == nil {
+		active = new(bool)
+	}
+	cactive := C.bool(*active)
+	defer func() {
+		*active = bool(cactive)
+	}()
+
+	// NOTE: This only returns 0 on raylib.h
+	return C.GuiToggle(cbounds, ctext, &cactive) != 0
 }
 
 // ToggleGroup control, returns active toggle index
-func ToggleGroup(bounds rl.Rectangle, text string, active int32) int32 {
+func ToggleGroup(bounds rl.Rectangle, text string, active *int32) bool {
 	var cbounds C.struct_Rectangle
 	cbounds.x = C.float(bounds.X)
 	cbounds.y = C.float(bounds.Y)
@@ -755,30 +774,46 @@ func ToggleGroup(bounds rl.Rectangle, text string, active int32) int32 {
 		ctext = C.CString(text)
 		defer C.free(unsafe.Pointer(ctext))
 	}
-	cactive := C.int(active)
-	C.GuiToggleGroup(cbounds, ctext, &cactive)
-	return int32(cactive)
+
+	if active == nil {
+		active = new(int32)
+	}
+	cactive := C.int(*active)
+	defer func() {
+		*active = int32(cactive)
+	}()
+
+	return C.GuiToggleGroup(cbounds, ctext, &cactive) != 0
 }
 
 // ToggleSlider control, returns true when clicked
-func ToggleSlider(bounds rl.Rectangle, text string, active int32) int32 {
+func ToggleSlider(bounds rl.Rectangle, text string, active *int32) bool {
 	var cbounds C.struct_Rectangle
 	cbounds.x = C.float(bounds.X)
 	cbounds.y = C.float(bounds.Y)
 	cbounds.width = C.float(bounds.Width)
 	cbounds.height = C.float(bounds.Height)
+
 	var ctext *C.char
 	if len(text) > 0 {
 		ctext = C.CString(text)
 		defer C.free(unsafe.Pointer(ctext))
 	}
-	cactive := C.int(active)
-	C.GuiToggleSlider(cbounds, ctext, &cactive)
-	return int32(cactive)
+
+	if active == nil {
+		active = new(int32)
+	}
+
+	cactive := C.int(*active)
+	defer func() {
+		*active = int32(cactive)
+	}()
+
+	return C.GuiToggleSlider(cbounds, ctext, &cactive) != 0
 }
 
 // CheckBox control, returns true when active
-func CheckBox(bounds rl.Rectangle, text string, checked bool) bool {
+func CheckBox(bounds rl.Rectangle, text string, checked *bool) bool {
 	var cbounds C.struct_Rectangle
 	cbounds.x = C.float(bounds.X)
 	cbounds.y = C.float(bounds.Y)
@@ -789,13 +824,20 @@ func CheckBox(bounds rl.Rectangle, text string, checked bool) bool {
 		ctext = C.CString(text)
 		defer C.free(unsafe.Pointer(ctext))
 	}
-	cchecked := C.bool(checked)
-	C.GuiCheckBox(cbounds, ctext, &cchecked)
-	return bool(cchecked)
+
+	if checked == nil {
+		checked = new(bool)
+	}
+	cchecked := C.bool(*checked)
+	defer func() {
+		*checked = bool(cchecked)
+	}()
+
+	return C.GuiCheckBox(cbounds, ctext, &cchecked) != 0
 }
 
 // ComboBox control, returns selected item index
-func ComboBox(bounds rl.Rectangle, text string, active int32) int32 {
+func ComboBox(bounds rl.Rectangle, text string, active *int32) bool {
 	var cbounds C.struct_Rectangle
 	cbounds.x = C.float(bounds.X)
 	cbounds.y = C.float(bounds.Y)
@@ -806,9 +848,17 @@ func ComboBox(bounds rl.Rectangle, text string, active int32) int32 {
 		ctext = C.CString(text)
 		defer C.free(unsafe.Pointer(ctext))
 	}
-	cactive := C.int(active)
-	C.GuiComboBox(cbounds, ctext, &cactive)
-	return int32(cactive)
+
+	if active == nil {
+		active = new(int32)
+	}
+	cactive := C.int(*active)
+	defer func() {
+		*active = int32(cactive)
+	}()
+
+	// NOTE: This only returns 0 on raylib.h
+	return C.GuiComboBox(cbounds, ctext, &cactive) != 0
 }
 
 // DropdownBox control, returns true when clicked
@@ -889,6 +939,7 @@ func Spinner(bounds rl.Rectangle, text string, value *int32, minValue, maxValue 
 	cmaxValue := C.int(maxValue)
 	ceditMode := C.bool(editMode)
 
+	// NOTE: Returns the same as C.GuiValueBox
 	return C.GuiSpinner(cbounds, ctext, &cvalue, cminValue, cmaxValue, ceditMode) != 0
 }
 
@@ -954,11 +1005,13 @@ func ValueBoxFloat(bounds rl.Rectangle, text string, textValue *string, value *f
 		*value = float32(cvalue)
 	}()
 
-	return C.GuiValueBoxFloat(cbounds, ctext, ctextValue, &cvalue, C.bool(editMode)) != 0
+	ceditMode := C.bool(editMode)
+
+	return C.GuiValueBoxFloat(cbounds, ctext, ctextValue, &cvalue, ceditMode) != 0
 }
 
 // Slider control
-func Slider(bounds rl.Rectangle, textLeft, textRight string, value, minValue, maxValue float32) float32 {
+func Slider(bounds rl.Rectangle, textLeft, textRight string, value *float32, minValue, maxValue float32) bool {
 	var cbounds C.struct_Rectangle
 	cbounds.x = C.float(bounds.X)
 	cbounds.y = C.float(bounds.Y)
@@ -977,15 +1030,23 @@ func Slider(bounds rl.Rectangle, textLeft, textRight string, value, minValue, ma
 		defer C.free(unsafe.Pointer(ctextRight))
 	}
 
-	cvalue := C.float(value)
+	if value == nil {
+		value = new(float32)
+	}
+	cvalue := C.float(*value)
+	defer func() {
+		*value = float32(cvalue)
+	}()
+
 	cminValue := C.float(minValue)
 	cmaxValue := C.float(maxValue)
-	C.GuiSlider(cbounds, ctextLeft, ctextRight, &cvalue, cminValue, cmaxValue)
-	return float32(cvalue)
+
+	// NOTE: 0 if value didn't change, 1 otherwise
+	return C.GuiSlider(cbounds, ctextLeft, ctextRight, &cvalue, cminValue, cmaxValue) != 0
 }
 
 // SliderBar control, returns selected value
-func SliderBar(bounds rl.Rectangle, textLeft, textRight string, value, minValue, maxValue float32) float32 {
+func SliderBar(bounds rl.Rectangle, textLeft, textRight string, value *float32, minValue, maxValue float32) bool {
 	var cbounds C.struct_Rectangle
 	cbounds.width = C.float(bounds.Width)
 	cbounds.height = C.float(bounds.Height)
@@ -1004,15 +1065,23 @@ func SliderBar(bounds rl.Rectangle, textLeft, textRight string, value, minValue,
 		defer C.free(unsafe.Pointer(ctextRight))
 	}
 
-	cvalue := C.float(value)
+	if value == nil {
+		value = new(float32)
+	}
+	cvalue := C.float(*value)
+	defer func() {
+		*value = float32(cvalue)
+	}()
+
 	cminValue := C.float(minValue)
 	cmaxValue := C.float(maxValue)
-	C.GuiSliderBar(cbounds, ctextLeft, ctextRight, &cvalue, cminValue, cmaxValue)
-	return float32(cvalue)
+
+	// NOTE: Returns the same as C.GuiSlider
+	return C.GuiSliderBar(cbounds, ctextLeft, ctextRight, &cvalue, cminValue, cmaxValue) != 0
 }
 
 // ProgressBar control, shows current progress value
-func ProgressBar(bounds rl.Rectangle, textLeft, textRight string, value, minValue, maxValue float32) float32 {
+func ProgressBar(bounds rl.Rectangle, textLeft, textRight string, value *float32, minValue, maxValue float32) bool {
 	var cbounds C.struct_Rectangle
 	cbounds.width = C.float(bounds.Width)
 	cbounds.height = C.float(bounds.Height)
@@ -1031,15 +1100,23 @@ func ProgressBar(bounds rl.Rectangle, textLeft, textRight string, value, minValu
 		defer C.free(unsafe.Pointer(ctextRight))
 	}
 
-	cvalue := C.float(value)
+	if value == nil {
+		value = new(float32)
+	}
+	cvalue := C.float(*value)
+	defer func() {
+		*value = float32(cvalue)
+	}()
+
 	cminValue := C.float(minValue)
 	cmaxValue := C.float(maxValue)
-	C.GuiProgressBar(cbounds, ctextLeft, ctextRight, &cvalue, cminValue, cmaxValue)
-	return float32(cvalue)
+
+	// NOTE: This only returns 0 on raylib.h
+	return C.GuiProgressBar(cbounds, ctextLeft, ctextRight, &cvalue, cminValue, cmaxValue) != 0
 }
 
 // StatusBar control, shows info text
-func StatusBar(bounds rl.Rectangle, text string) {
+func StatusBar(bounds rl.Rectangle, text string) bool {
 	var cbounds C.struct_Rectangle
 	cbounds.x = C.float(bounds.X)
 	cbounds.y = C.float(bounds.Y)
@@ -1050,11 +1127,13 @@ func StatusBar(bounds rl.Rectangle, text string) {
 		ctext = C.CString(text)
 		defer C.free(unsafe.Pointer(ctext))
 	}
-	C.GuiStatusBar(cbounds, ctext)
+
+	// NOTE: This only returns 0 on raylib.h
+	return C.GuiStatusBar(cbounds, ctext) != 0
 }
 
 // DummyRectangle control, intended for placeholding
-func DummyRec(bounds rl.Rectangle, text string) {
+func DummyRec(bounds rl.Rectangle, text string) bool {
 	var cbounds C.struct_Rectangle
 	cbounds.x = C.float(bounds.X)
 	cbounds.y = C.float(bounds.Y)
@@ -1065,11 +1144,13 @@ func DummyRec(bounds rl.Rectangle, text string) {
 		ctext = C.CString(text)
 		defer C.free(unsafe.Pointer(ctext))
 	}
-	C.GuiDummyRec(cbounds, ctext)
+	
+	// NOTE: This only returns 0 on raylib.h
+	return C.GuiDummyRec(cbounds, ctext) != 0
 }
 
 // ListView control, returns selected list item index
-func ListView(bounds rl.Rectangle, text string, scrollIndex *int32, active int32) int32 {
+func ListView(bounds rl.Rectangle, text string, scrollIndex *int32, active *int32) bool {
 	var cbounds C.struct_Rectangle
 	cbounds.x = C.float(bounds.X)
 	cbounds.y = C.float(bounds.Y)
@@ -1089,14 +1170,20 @@ func ListView(bounds rl.Rectangle, text string, scrollIndex *int32, active int32
 		*scrollIndex = int32(cscrollIndex)
 	}()
 
-	cactive := C.int(active)
+	if active == nil {
+		active = new(int32)
+	}
+	cactive := C.int(*active)
+	defer func() {
+		*active = int32(cactive)
+	}()
 
-	C.GuiListView(cbounds, ctext, &cscrollIndex, &cactive)
-	return int32(cactive)
+	// NOTE: Returns the same as C.GuiListViewEx (only 0 on raylib.h)
+	return C.GuiListView(cbounds, ctext, &cscrollIndex, &cactive) != 0
 }
 
 // ListView control with extended parameters
-func ListViewEx(bounds rl.Rectangle, text []string, focus, scrollIndex *int32, active int32) int32 {
+func ListViewEx(bounds rl.Rectangle, text []string, focus, scrollIndex *int32, active *int32) bool {
 	var cbounds C.struct_Rectangle
 	cbounds.x = C.float(bounds.X)
 	cbounds.y = C.float(bounds.Y)
@@ -1124,14 +1211,20 @@ func ListViewEx(bounds rl.Rectangle, text []string, focus, scrollIndex *int32, a
 		*scrollIndex = int32(cscrollIndex)
 	}()
 
-	cactive := C.int(active)
+	if active == nil {
+		active = new(int32)
+	}
+	cactive := C.int(*active)
+	defer func() {
+		*active = int32(cactive)
+	}()
 
-	C.GuiListViewEx(cbounds, (**C.char)(ctext.Pointer), count, &cfocus, &cscrollIndex, &cactive)
-	return int32(cactive)
+	// NOTE: This only returns 0 on raylib.h
+	return C.GuiListViewEx(cbounds, (**C.char)(ctext.Pointer), count, &cfocus, &cscrollIndex, &cactive) != 0
 }
 
 // ColorPanel control, Color (RGBA) variant
-func ColorPanel(bounds rl.Rectangle, text string, color rl.Color) rl.Color {
+func ColorPanel(bounds rl.Rectangle, text string, color *rl.Color) bool {
 	var cbounds C.struct_Rectangle
 	cbounds.x = C.float(bounds.X)
 	cbounds.y = C.float(bounds.Y)
@@ -1147,17 +1240,20 @@ func ColorPanel(bounds rl.Rectangle, text string, color rl.Color) rl.Color {
 	ccolor.a = C.uchar(color.A)
 	ccolor.r = C.uchar(color.R)
 	ccolor.g = C.uchar(color.G)
-	C.GuiColorPanel(cbounds, ctext, &ccolor)
-	var goRes rl.Color
-	goRes.A = byte(ccolor.a)
-	goRes.R = byte(ccolor.r)
-	goRes.G = byte(ccolor.g)
-	goRes.B = byte(ccolor.b)
-	return goRes
+
+	// NOTE: This only returns 0 on raylib.h
+	res := C.GuiColorPanel(cbounds, ctext, &ccolor)
+
+	color.A = byte(ccolor.a)
+	color.R = byte(ccolor.r)
+	color.G = byte(ccolor.g)
+	color.B = byte(ccolor.b)
+
+	return res != 0
 }
 
 // ColorBarAlpha control, returns alpha value normalized [0..1]
-func ColorBarAlpha(bounds rl.Rectangle, text string, alpha float32) float32 {
+func ColorBarAlpha(bounds rl.Rectangle, text string, alpha *float32) bool {
 	var cbounds C.struct_Rectangle
 	cbounds.width = C.float(bounds.Width)
 	cbounds.height = C.float(bounds.Height)
@@ -1168,13 +1264,21 @@ func ColorBarAlpha(bounds rl.Rectangle, text string, alpha float32) float32 {
 		ctext = C.CString(text)
 		defer C.free(unsafe.Pointer(ctext))
 	}
-	calpha := C.float(alpha)
-	C.GuiColorBarAlpha(cbounds, ctext, &calpha)
-	return float32(calpha)
+
+	if alpha == nil {
+		alpha = new(float32)
+	}
+	calpha := C.float(*alpha)
+	defer func() {
+		*alpha = float32(calpha)
+	}()
+
+	// NOTE: This only returns 0 on raylib.h
+	return C.GuiColorBarAlpha(cbounds, ctext, &calpha) != 0
 }
 
 // ColorBarHue control, returns alpha value normalized [0..1]
-func ColorBarHue(bounds rl.Rectangle, text string, value float32) float32 {
+func ColorBarHue(bounds rl.Rectangle, text string, value *float32) bool {
 	var cbounds C.struct_Rectangle
 	cbounds.x = C.float(bounds.X)
 	cbounds.y = C.float(bounds.Y)
@@ -1185,14 +1289,22 @@ func ColorBarHue(bounds rl.Rectangle, text string, value float32) float32 {
 		ctext = C.CString(text)
 		defer C.free(unsafe.Pointer(ctext))
 	}
-	cvalue := C.float(value)
-	C.GuiColorBarHue(cbounds, ctext, &cvalue)
-	return float32(cvalue)
+
+	if value == nil {
+		value = new(float32)
+	}
+	cvalue := C.float(*value)
+	defer func() {
+		*value = float32(cvalue)
+	}()
+
+	// NOTE: This only returns 0 on raylib.h
+	return C.GuiColorBarHue(cbounds, ctext, &cvalue) != 0
 }
 
 // ColorPicker control (multiple color controls)
 // NOTE: this picker converts RGB to HSV, which can cause the Hue control to jump. If you have this problem, consider using the HSV variant instead
-func ColorPicker(bounds rl.Rectangle, text string, color rl.Color) rl.Color {
+func ColorPicker(bounds rl.Rectangle, text string, color *rl.Color) bool {
 	var cbounds C.struct_Rectangle
 	cbounds.width = C.float(bounds.Width)
 	cbounds.height = C.float(bounds.Height)
@@ -1208,17 +1320,20 @@ func ColorPicker(bounds rl.Rectangle, text string, color rl.Color) rl.Color {
 	ccolor.g = C.uchar(color.G)
 	ccolor.b = C.uchar(color.B)
 	ccolor.a = C.uchar(color.A)
-	C.GuiColorPicker(cbounds, ctext, &ccolor)
-	var goRes rl.Color
-	goRes.A = byte(ccolor.a)
-	goRes.R = byte(ccolor.r)
-	goRes.G = byte(ccolor.g)
-	goRes.B = byte(ccolor.b)
-	return goRes
+
+	// NOTE: This only returns 0 on raylib.h
+	res := C.GuiColorPicker(cbounds, ctext, &ccolor)
+
+	color.A = byte(ccolor.a)
+	color.R = byte(ccolor.r)
+	color.G = byte(ccolor.g)
+	color.B = byte(ccolor.b)
+
+	return res != 0
 }
 
 // ColorPicker control that avoids conversion to RGB on each call (multiple color controls)
-func ColorPickerHSV(bounds rl.Rectangle, text string, colorHSV *rl.Vector3) int32 {
+func ColorPickerHSV(bounds rl.Rectangle, text string, colorHSV *rl.Vector3) bool {
 	var cbounds C.struct_Rectangle
 	cbounds.width = C.float(bounds.Width)
 	cbounds.height = C.float(bounds.Height)
@@ -1241,11 +1356,12 @@ func ColorPickerHSV(bounds rl.Rectangle, text string, colorHSV *rl.Vector3) int3
 		colorHSV.Z = float32(ccolorHSV.z)
 	}()
 
-	return int32(C.GuiColorPickerHSV(cbounds, ctext, &ccolorHSV))
+	// NOTE: This only returns 0 on raylib.h
+	return C.GuiColorPickerHSV(cbounds, ctext, &ccolorHSV) != 0
 }
 
 // ColorPanel control that returns HSV color value
-func ColorPanelHSV(bounds rl.Rectangle, text string, colorHSV *rl.Vector3) int32 {
+func ColorPanelHSV(bounds rl.Rectangle, text string, colorHSV *rl.Vector3) bool {
 	var cbounds C.struct_Rectangle
 	cbounds.width = C.float(bounds.Width)
 	cbounds.height = C.float(bounds.Height)
@@ -1268,7 +1384,8 @@ func ColorPanelHSV(bounds rl.Rectangle, text string, colorHSV *rl.Vector3) int32
 		colorHSV.Z = float32(ccolorHSV.z)
 	}()
 
-	return int32(C.GuiColorPanelHSV(cbounds, ctext, &ccolorHSV))
+	// NOTE: This only returns 0 on raylib.h
+	return C.GuiColorPanelHSV(cbounds, ctext, &ccolorHSV) != 0
 }
 
 // MessageBox control
@@ -1290,6 +1407,7 @@ func MessageBox(bounds rl.Rectangle, title, message, buttons string) int32 {
 	}
 	cbuttons := C.CString(buttons)
 	defer C.free(unsafe.Pointer(cbuttons))
+
 	return int32(C.GuiMessageBox(cbounds, ctitle, cmessage, cbuttons))
 }
 
@@ -1340,7 +1458,7 @@ func TextInputBox(bounds rl.Rectangle, title, message, buttons string, text *str
 }
 
 // Grid control, returns mouse cell position
-func Grid(bounds rl.Rectangle, text string, spacing float32, subdivs int32, mouseCell *rl.Vector2) int32 {
+func Grid(bounds rl.Rectangle, text string, spacing float32, subdivs int32, mouseCell *rl.Vector2) bool {
 	var cbounds C.struct_Rectangle
 	cbounds.y = C.float(bounds.Y)
 	cbounds.width = C.float(bounds.Width)
@@ -1353,13 +1471,18 @@ func Grid(bounds rl.Rectangle, text string, spacing float32, subdivs int32, mous
 	}
 	cspacing := C.float(spacing)
 	csubdivs := C.int(subdivs)
+
 	var cmouseCell C.struct_Vector2
 	cmouseCell.x = C.float(mouseCell.X)
 	cmouseCell.y = C.float(mouseCell.Y)
+
+	// NOTE: This only returns 0 on raylib.h
 	res := C.GuiGrid(cbounds, ctext, cspacing, csubdivs, &cmouseCell)
+
 	mouseCell.X = float32(cmouseCell.x)
 	mouseCell.Y = float32(cmouseCell.y)
-	return int32(res)
+
+	return res != 0
 }
 
 //----------------------------------------------------------------------------------
@@ -1408,6 +1531,7 @@ func IconText(iconId IconID, text string) string {
 	return C.GoString(C.GuiIconText(ciconId, ctext))
 }
 
+// TODO change this so it returns []string
 // Load raygui icons file (.rgi)
 func LoadIcons(fileName string, loadIconsName bool) {
 	cfileName := C.CString(fileName)
@@ -1415,6 +1539,7 @@ func LoadIcons(fileName string, loadIconsName bool) {
 	C.GuiLoadIcons(cfileName, C.bool(loadIconsName))
 }
 
+// TODO change this so it returns []string
 // Load icons from memory (Binary files only)
 func LoadIconsFromMemory(data []byte, loadIconsName bool) {
 	C.GuiLoadIconsFromMemory((*C.uchar)(unsafe.Pointer(&data[0])), C.int(len(data)), C.bool(loadIconsName))


### PR DESCRIPTION
This PR brings the bindings closer to the original raygui.h, as previously some functions received arguments as value instead of reference and returned values instead of component state.

Add return value:
- GroupBox
- Line
- Panel
- ScrollPanel
- Label
- StatusBar
- DummyRec

Change return type:
- ColorPickerHSV
- ColorPanelHSV
- Grid

Pass arguments as pointer instead of value, and change return type:
- Toggle
- ToggleGroup
- ToggleSlider
- CheckBox
- ComboBox
- Slider
- SliderBar
- ProgressBar
- ListView
- ListViewEx
- ColorPanel
- ColorBarAlpha
- ColorBarHue
- ColorPicker

Fix examples that failed to compile after the previous changes:
- easings/easings/main.go
- gui/controls_test_suite/controls_test_suite.go
- gui/portable_window/portable_window.go
- gui/scroll_panel/scroll_panel.go
- shapes/draw_circle_sector/main.go
- shapes/draw_ring/main.go