### PR TITLE
raygui: fix buffer overflow crash in TextBox when string is smaller than textSize

### DIFF
--- a/raygui/raygui.go
+++ b/raygui/raygui.go
@@ -896,22 +896,24 @@ func TextBox(bounds rl.Rectangle, text *string, textSize int, editMode bool) boo
 	cbounds.height = C.float(bounds.Height)
 
 	bs := []byte(*text)
-	if len(bs) == 0 {
-		bs = []byte{byte(0)}
+	if len(bs) < textSize {
+		newBs := make([]byte, textSize)
+		copy(newBs, bs)
+		bs = newBs
 	}
-	if 0 < len(bs) && bs[len(bs)-1] != byte(0) { // minimalize allocation
-		bs = append(bs, byte(0)) // for next input symbols
-	}
-	ctext := (*C.char)(unsafe.Pointer(&bs[0]))
-	defer func() {
-		*text = strings.Trim(string(bs), "\x00")
-		// no need : C.free(unsafe.Pointer(ctext))
-	}()
+
+	// C.CString creates a copy of the Go string on the C heap.
+	// This avoids passing Go memory to C, completely eliminating heap corruption.
+	ctext := C.CString(string(bs))
+	defer C.free(unsafe.Pointer(ctext))
 
 	ctextSize := C.int(textSize)
 	ceditMode := C.bool(editMode)
 
-	return C.GuiTextBox(cbounds, ctext, ctextSize, ceditMode) != 0
+	result := C.GuiTextBox(cbounds, ctext, ctextSize, ceditMode) != 0
+
+	*text = C.GoString(ctext)
+	return result
 }
 
 // Spinner control, sets value to the selected number and returns true when clicked.


### PR DESCRIPTION
### Description
Fixes a heap corruption/buffer overflow crash when calling `raygui.TextBox` with a string that is shorter than the requested `textSize` (e.g., an empty string `""` with a `textSize` of `25`).

### Root Cause
In Go, `bs := []byte(*text)` creates a byte slice whose size is bound to the string's current length, rather than the requested `textSize`. 
If `len(bs)` is smaller than `textSize`, the C function `GuiTextBox` receives a pointer to a small Go-allocated buffer but expects it to be at least `textSize` bytes. When typing a character, `GuiTextBox` writes out-of-bounds, corrupting the Go heap and causing access violations / segmentation faults.

### Solution
1. **Ensured Minimum Buffer Capacity**: If the string slice `bs` is smaller than `textSize`, it is re-allocated to have a length of at least `textSize` (`newBs := make([]byte, textSize); copy(newBs, bs)`).
2. **Migrated to C-Heap Allocation (`C.CString`)**: Instead of passing a Go garbage-collected slice pointer directly to C (`&bs[0]`), which violates cgo pointer-passing rules for mutable buffers, we now copy it safely to the C-heap using `C.CString(string(bs))`.
3. **Safe Memory Cleanup & Synchronization**: We defer freeing the C-allocated memory using `C.free` and successfully copy the updated string back into Go memory with `*text = C.GoString(ctext)` after `GuiTextBox` executes.
